### PR TITLE
[ᚬckb-v0.20] fix: Use wrong script hash to check dao cell

### DIFF
--- a/src/subcommands/wallet/mod.rs
+++ b/src/subcommands/wallet/mod.rs
@@ -12,7 +12,7 @@ use ckb_jsonrpc_types::{BlockNumber, CellWithStatus, HeaderView, TransactionWith
 use ckb_types::{
     bytes::Bytes,
     core::{service::Request, BlockView, TransactionView},
-    packed::{Byte32, CellInput, Script},
+    packed::{Byte32, CellInput},
     prelude::*,
     H160, H256,
 };
@@ -527,11 +527,11 @@ impl<'a> WalletSubCommand<'a> {
         format: OutputFormat,
         color: bool,
     ) -> Result<String, String> {
-        let transaction_view: ckb_jsonrpc_types::TransactionView = transaction.clone().into();
-        println!(
-            "[Send Transaction]:\n{}",
-            transaction_view.render(format, color)
-        );
+        //        let transaction_view: ckb_jsonrpc_types::TransactionView = transaction.clone().into();
+        //        println!(
+        //            "[Send Transaction]:\n{}",
+        //            transaction_view.render(format, color)
+        //        );
 
         let resp = self
             .rpc_client
@@ -763,12 +763,9 @@ fn is_dao_cell(cell: &CellWithStatus, dao_type_hash: &Byte32) -> bool {
         return output
             .type_
             .as_ref()
-            .map(|script| {
-                let type_hash = Into::<Script>::into(script.to_owned()).calc_script_hash();
-                &type_hash == dao_type_hash
-            })
+            .map(|script| &script.code_hash.pack() == dao_type_hash)
             .unwrap_or(false);
-    }
+    };
 
     false
 }


### PR DESCRIPTION
We should use `output.type_script.code_hash == dao_type_hash` to check dao cell, but not `output.type_script.calc_script_hash()`. This bug introduced from ad626da34760d039282b9f7292fc29f5d2f22cbf