### PR TITLE
fix: remove duplicate command, util key-info is enough

### DIFF
--- a/ckb-index/src/index/types.rs
+++ b/ckb-index/src/index/types.rs
@@ -560,27 +560,8 @@ impl LockInfo {
         }
     }
 
-    fn set_script(&mut self, script: Script, secp_type_hash: &Byte32) {
-        let type_hash = script.calc_script_hash();
-        let address_opt = if &type_hash == secp_type_hash {
-            if script.args().len() == 1 {
-                let lock_arg = script.args().raw_data();
-                match Address::from_lock_arg(&lock_arg) {
-                    Ok(address) => Some(address),
-                    Err(err) => {
-                        log::info!("Invalid secp arg: {:?} => {}", lock_arg, err);
-                        None
-                    }
-                }
-            } else {
-                log::info!("lock arg should given exact 1");
-                None
-            }
-        } else {
-            None
-        };
+    fn set_script(&mut self, script: Script, _secp_type_hash: &Byte32) {
         self.script_opt = Some(script.as_slice().into());
-        self.address_opt = address_opt;
     }
 
     fn add_input(&mut self, input_capacity: u64) {

--- a/src/subcommands/util.rs
+++ b/src/subcommands/util.rs
@@ -182,7 +182,8 @@ impl<'a> CliSubCommand for UtilSubCommand<'a> {
 [block_assembler]
 code_hash = "{:#x}"
 hash_type = "type"
-args = ["{:#x}"]
+args = "{:#x}"
+message = "0x"
 "#,
                     secp_type_hash,
                     address.hash()


### PR DESCRIPTION
1. Remove duplicate command, util key-info is enough
2. Temporarily turn off `address -> lock` storage(The default single sign is not required, and may be extended to any `address -> lock` mapping in the future)
3. `arg` output is str instead of the list