### PR TITLE
feat: Add common transaction (sighash/multisig) sub-commands

### DIFF
--- a/ckb-sdk/src/tx_helper.rs
+++ b/ckb-sdk/src/tx_helper.rs
@@ -2,7 +2,7 @@ use ckb_hash::{blake2b_256, new_blake2b};
 use ckb_types::{
     bytes::Bytes,
     core::{ScriptHashType, TransactionBuilder, TransactionView},
-    packed::{self, Byte32, CellInput, CellOutput, OutPoint, Script, WitnessArgs},
+    packed::{self, Byte32, CellDep, CellInput, CellOutput, OutPoint, Script, WitnessArgs},
     prelude::*,
     H160, H256,
 };
@@ -82,34 +82,35 @@ impl TxHelper {
         mut get_live_cell: F,
         genesis_info: &GenesisInfo,
     ) -> Result<(), String> {
-        let mut since_value_opt =
-            since_absolute_epoch_opt.map(|number| Since::new_absolute_epoch(number).value());
-
         let lock = get_live_cell(out_point.clone(), false)?.lock();
         check_lock_script(&lock)?;
-        if since_value_opt.is_none() {
+
+        let since = if let Some(number) = since_absolute_epoch_opt {
+            Since::new_absolute_epoch(number).value()
+        } else {
             let lock_arg = lock.args().raw_data();
             if lock.code_hash() == MULTISIG_TYPE_HASH.pack() && lock_arg.len() == 28 {
                 let mut since_bytes = [0u8; 8];
                 since_bytes.copy_from_slice(&lock_arg[20..]);
-                let since_value = u64::from_le_bytes(since_bytes);
-                since_value_opt = Some(since_value);
+                u64::from_le_bytes(since_bytes)
+            } else {
+                0
             }
-        }
-        let since = since_value_opt.unwrap_or(0);
+        };
+
         let input = CellInput::new_builder()
             .previous_output(out_point)
             .since(since.pack())
             .build();
 
         self.transaction = self.transaction.as_advanced_builder().input(input).build();
-        let mut cell_deps = Vec::new();
+        let mut cell_deps: HashSet<CellDep> = HashSet::default();
         for ((code_hash, _), _) in self.input_group(get_live_cell)?.into_iter() {
             let code_hash: H256 = code_hash.unpack();
             if code_hash == SIGHASH_TYPE_HASH {
-                cell_deps.push(genesis_info.sighash_dep());
+                cell_deps.insert(genesis_info.sighash_dep());
             } else if code_hash == MULTISIG_TYPE_HASH {
-                cell_deps.push(genesis_info.multisig_dep());
+                cell_deps.insert(genesis_info.multisig_dep());
             } else {
                 panic!("Unexpected input code_hash: {:#x}", code_hash);
             }
@@ -117,7 +118,7 @@ impl TxHelper {
         self.transaction = self
             .transaction
             .as_advanced_builder()
-            .set_cell_deps(cell_deps)
+            .set_cell_deps(cell_deps.into_iter().collect())
             .build();
         Ok(())
     }
@@ -175,9 +176,8 @@ impl TxHelper {
                 && !self.multisig_configs.contains_key(&hash160)
             {
                 return Err(format!(
-                    "Invalid input(no.{}) lock script args prefix: 0x{}, expected: {:#x}",
+                    "No mutisig config found for input(no.{}) lock_arg prefix: {:#x}",
                     idx + 1,
-                    hex_string(&lock_arg[..20]).unwrap(),
                     hash160,
                 ));
             }
@@ -197,6 +197,7 @@ impl TxHelper {
         witnesses
     }
 
+    // FIXME: remove this later
     pub fn sign_sighash_inputs<S, C>(
         &self,
         mut signer: S,
@@ -225,14 +226,13 @@ impl TxHelper {
         Ok(signatures)
     }
 
-    pub fn sign_multisig_inputs<S, C>(
+    pub fn sign_inputs<S, C>(
         &self,
-        signer_lock_arg: &H160,
         mut signer: S,
         get_live_cell: C,
     ) -> Result<HashMap<Bytes, Bytes>, String>
     where
-        S: FnMut(&H256) -> Result<[u8; SECP_SIGNATURE_SIZE], String>,
+        S: FnMut(&HashSet<H160>, &H256) -> Result<Option<[u8; 65]>, String>,
         C: FnMut(OutPoint, bool) -> Result<CellOutput, String>,
     {
         let all_sighash_lock_args = self
@@ -244,28 +244,27 @@ impl TxHelper {
         let witnesses = self.init_witnesses();
         let mut signatures: HashMap<Bytes, Bytes> = Default::default();
         for ((code_hash, lock_arg), idxs) in self.input_group(get_live_cell)?.into_iter() {
-            if code_hash == SIGHASH_TYPE_HASH.pack() {
-                continue;
-            }
-
-            let hash160 = H160::from_slice(&lock_arg[..20]).unwrap();
-            if code_hash == MULTISIG_TYPE_HASH.pack()
-                && !all_sighash_lock_args
-                    .get(&hash160)
+            let multisig_hash160 = H160::from_slice(&lock_arg[..20]).unwrap();
+            let lock_args = if code_hash == MULTISIG_TYPE_HASH.pack() {
+                all_sighash_lock_args
+                    .get(&multisig_hash160)
                     .unwrap()
-                    .contains(signer_lock_arg)
-            {
-                continue;
+                    .clone()
+            } else {
+                let mut lock_args = HashSet::default();
+                lock_args.insert(H160::from_slice(lock_arg.as_ref()).unwrap());
+                lock_args
+            };
+            if signer(&lock_args, &SIGHASH_TYPE_HASH)?.is_some() {
+                let signature = build_signature(
+                    &self.transaction.hash(),
+                    &idxs,
+                    &witnesses,
+                    self.multisig_configs.get(&multisig_hash160),
+                    |message: &H256| signer(&lock_args, message).map(|sig| sig.unwrap()),
+                )?;
+                signatures.insert(lock_arg, signature);
             }
-
-            let signature = build_signature(
-                &self.transaction.hash(),
-                &idxs,
-                &witnesses,
-                Some(self.multisig_configs.get(&hash160).unwrap()),
-                &mut signer,
-            )?;
-            signatures.insert(lock_arg, signature);
         }
         Ok(signatures)
     }
@@ -277,9 +276,14 @@ impl TxHelper {
         let mut witnesses = self.init_witnesses();
         for ((code_hash, lock_arg), idxs) in self.input_group(get_live_cell)?.into_iter() {
             let signatures = self.signatures.get(&lock_arg).ok_or_else(|| {
+                let lock_script = Script::new_builder()
+                    .hash_type(ScriptHashType::Type.into())
+                    .code_hash(code_hash.clone())
+                    .args(lock_arg.pack())
+                    .build();
                 format!(
-                    "Missing signatures for lock_arg: 0x{}",
-                    hex_string(&lock_arg).unwrap()
+                    "Missing signatures for lock_hash: {:#x}",
+                    lock_script.calc_script_hash()
                 )
             })?;
             let lock_field = if code_hash == MULTISIG_TYPE_HASH.pack() {

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -13,7 +13,7 @@ use serde_json::json;
 
 use crate::subcommands::{
     AccountSubCommand, CliSubCommand, IndexController, IndexRequest, MockTxSubCommand,
-    MoleculeSubCommand, RpcSubCommand, UtilSubCommand, WalletSubCommand,
+    MoleculeSubCommand, RpcSubCommand, TxSubCommand, UtilSubCommand, WalletSubCommand,
 };
 use crate::utils::{
     completer::CkbCompleter,
@@ -323,6 +323,14 @@ impl InteractiveEnv {
                         genesis_info,
                     )
                     .process(&sub_matches, format, color, debug)?;
+                    println!("{}", output);
+                    Ok(())
+                }
+                ("tx", Some(sub_matches)) => {
+                    let genesis_info = self.genesis_info().ok();
+                    let output =
+                        TxSubCommand::new(&mut self.rpc_client, &mut self.key_store, genesis_info)
+                            .process(&sub_matches, format, color, debug)?;
                     println!("{}", output);
                     Ok(())
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,7 +17,7 @@ use subcommands::TuiSubCommand;
 use interactive::InteractiveEnv;
 use subcommands::{
     start_index_thread, AccountSubCommand, CliSubCommand, IndexThreadState, MockTxSubCommand,
-    MoleculeSubCommand, RpcSubCommand, UtilSubCommand, WalletSubCommand,
+    MoleculeSubCommand, RpcSubCommand, TxSubCommand, UtilSubCommand, WalletSubCommand,
 };
 use utils::other::sync_to_tip;
 use utils::{
@@ -132,6 +132,14 @@ fn main() -> Result<(), io::Error> {
                 debug,
             )
         }),
+        ("tx", Some(sub_matches)) => get_key_store(&ckb_cli_dir).and_then(|mut key_store| {
+            TxSubCommand::new(&mut rpc_client, &mut key_store, None).process(
+                &sub_matches,
+                output_format,
+                color,
+                debug,
+            )
+        }),
         ("util", Some(sub_matches)) => {
             UtilSubCommand::new(&mut rpc_client).process(&sub_matches, output_format, color, debug)
         }
@@ -219,6 +227,7 @@ pub fn build_cli<'a>(version_short: &'a str, version_long: &'a str) -> App<'a, '
         .subcommand(RpcSubCommand::subcommand())
         .subcommand(AccountSubCommand::subcommand("account"))
         .subcommand(MockTxSubCommand::subcommand("mock-tx"))
+        .subcommand(TxSubCommand::subcommand("tx"))
         .subcommand(UtilSubCommand::subcommand("util"))
         .subcommand(MoleculeSubCommand::subcommand("molecule"))
         .subcommand(WalletSubCommand::subcommand())
@@ -320,6 +329,7 @@ pub fn build_interactive() -> App<'static, 'static> {
         .subcommand(RpcSubCommand::subcommand())
         .subcommand(AccountSubCommand::subcommand("account"))
         .subcommand(MockTxSubCommand::subcommand("mock-tx"))
+        .subcommand(TxSubCommand::subcommand("tx"))
         .subcommand(UtilSubCommand::subcommand("util"))
         .subcommand(MoleculeSubCommand::subcommand("molecule"))
         .subcommand(WalletSubCommand::subcommand())

--- a/src/subcommands/mod.rs
+++ b/src/subcommands/mod.rs
@@ -4,6 +4,7 @@ pub mod molecule;
 pub mod rpc;
 #[cfg(unix)]
 pub mod tui;
+pub mod tx;
 pub mod util;
 pub mod wallet;
 
@@ -14,6 +15,7 @@ pub use account::AccountSubCommand;
 pub use mock_tx::MockTxSubCommand;
 pub use molecule::MoleculeSubCommand;
 pub use rpc::RpcSubCommand;
+pub use tx::TxSubCommand;
 pub use util::UtilSubCommand;
 pub use wallet::{
     start_index_thread, IndexController, IndexRequest, IndexResponse, IndexThreadState,

--- a/src/subcommands/tx.rs
+++ b/src/subcommands/tx.rs
@@ -1,0 +1,774 @@
+use std::collections::{HashMap, HashSet};
+use std::convert::TryFrom;
+use std::fs;
+use std::io::Write;
+use std::path::PathBuf;
+use std::str::FromStr;
+
+use ckb_hash::blake2b_256;
+use ckb_jsonrpc_types as json_types;
+use ckb_jsonrpc_types::JsonBytes;
+use ckb_sdk::{
+    constants::{MULTISIG_TYPE_HASH, SECP_SIGNATURE_SIZE, SIGHASH_TYPE_HASH},
+    wallet::KeyStore,
+    Address, AddressPayload, CodeHashIndex, GenesisInfo, HttpRpcClient, HumanCapacity,
+    MultisigConfig, NetworkType, TxHelper, SECP256K1,
+};
+use ckb_types::{
+    bytes::Bytes,
+    core::Capacity,
+    packed::{self, CellOutput, OutPoint, Script},
+    prelude::*,
+    H160, H256,
+};
+use clap::{App, Arg, ArgMatches, SubCommand};
+use faster_hex::hex_string;
+use serde_derive::{Deserialize, Serialize};
+
+use super::CliSubCommand;
+use crate::utils::{
+    arg,
+    arg_parser::{
+        AddressParser, ArgParser, CapacityParser, FilePathParser, FixedHashParser, FromStrParser,
+        HexParser, PrivkeyPathParser, PrivkeyWrapper,
+    },
+    other::{
+        check_capacity, get_genesis_info, get_live_cell, get_live_cell_with_cache,
+        get_network_type, get_to_data, read_password,
+    },
+    printer::{OutputFormat, Printable},
+};
+
+pub struct TxSubCommand<'a> {
+    rpc_client: &'a mut HttpRpcClient,
+    key_store: &'a mut KeyStore,
+    genesis_info: Option<GenesisInfo>,
+}
+
+impl<'a> TxSubCommand<'a> {
+    pub fn new(
+        rpc_client: &'a mut HttpRpcClient,
+        key_store: &'a mut KeyStore,
+        genesis_info: Option<GenesisInfo>,
+    ) -> TxSubCommand<'a> {
+        TxSubCommand {
+            rpc_client,
+            key_store,
+            genesis_info,
+        }
+    }
+
+    pub fn subcommand(name: &'static str) -> App<'static, 'static> {
+        let arg_tx_file = Arg::with_name("tx-file")
+            .long("tx-file")
+            .takes_value(true)
+            .validator(|input| FilePathParser::new(false).validate(input))
+            .required(true)
+            .help("Multisig transaction data file (format: json)");
+        let arg_sighash_address = Arg::with_name("sighash-address")
+            .long("sighash-address")
+            .takes_value(true)
+            .multiple(true)
+            .required(true)
+            .validator(|input| AddressParser::new_sighash().validate(input))
+            .help("Normal sighash address");
+        let arg_require_first_n = Arg::with_name("require-first-n")
+            .long("require-first-n")
+            .takes_value(true)
+            .default_value("0")
+            .validator(|input| FromStrParser::<u8>::default().validate(input))
+            .help("Require first n signatures of corresponding pubkey");
+        let arg_threshold = Arg::with_name("threshold")
+            .long("threshold")
+            .takes_value(true)
+            .default_value("1")
+            .validator(|input| FromStrParser::<u8>::default().validate(input))
+            .help("Multisig threshold");
+        let arg_since_absolute_epoch = Arg::with_name("since-absolute-epoch")
+            .long("since-absolute-epoch")
+            .takes_value(true)
+            .validator(|input| FromStrParser::<u64>::default().validate(input))
+            .help("Since absolute epoch number");
+
+        SubCommand::with_name(name)
+            .about("Handle common sighash/multisig transaction")
+            .subcommands(vec![
+                SubCommand::with_name("init")
+                    .about("Init a common (sighash/multisig) transaction")
+                    .arg(arg_tx_file.clone()),
+                SubCommand::with_name("add-multisig-config")
+                    .about("Add multisig config")
+                    .arg(arg_sighash_address.clone())
+                    .arg(arg_require_first_n.clone())
+                    .arg(arg_threshold.clone())
+                    .arg(arg_tx_file.clone()),
+                SubCommand::with_name("clear-field")
+                    .about("Remove all field items in transaction")
+                    .arg(
+                        Arg::with_name("field")
+                            .long("field")
+                            .takes_value(true)
+                            .required(true)
+                            .possible_values(&["inputs", "outputs", "signatures"])
+                            .help("The transaction field"),
+                    )
+                    .arg(arg_tx_file.clone()),
+                SubCommand::with_name("add-input")
+                    .about("Add cell input (with secp/multisig lock)")
+                    .arg(
+                        Arg::with_name("tx-hash")
+                            .long("tx-hash")
+                            .takes_value(true)
+                            .validator(|input| FixedHashParser::<H256>::default().validate(input))
+                            .required(true)
+                            .help("Transaction hash"),
+                    )
+                    .arg(
+                        Arg::with_name("index")
+                            .long("index")
+                            .takes_value(true)
+                            .validator(|input| FromStrParser::<u32>::default().validate(input))
+                            .required(true)
+                            .help("Transaction output index"),
+                    )
+                    .arg(arg_since_absolute_epoch.clone())
+                    .arg(arg_tx_file.clone()),
+                SubCommand::with_name("add-output")
+                    .about("Add cell output")
+                    .arg(
+                        Arg::with_name("to-sighash-address")
+                            .long("to-sighash-address")
+                            .conflicts_with_all(&[
+                                "to-short-multisig-address",
+                                "to-long-multisig-address",
+                            ])
+                            .takes_value(true)
+                            .validator(|input| AddressParser::new_sighash().validate(input))
+                            .help("To normal sighash address"),
+                    )
+                    .arg(
+                        Arg::with_name("to-short-multisig-address")
+                            .long("to-short-multisig-address")
+                            .conflicts_with("to-long-multisig-address")
+                            .takes_value(true)
+                            .validator(|input| AddressParser::new_multisig().validate(input))
+                            .help("To short multisig address"),
+                    )
+                    .arg(
+                        Arg::with_name("to-long-multisig-address")
+                            .long("to-long-multisig-address")
+                            .takes_value(true)
+                            .validator(|input| {
+                                AddressParser::default()
+                                    .set_full_type(MULTISIG_TYPE_HASH)
+                                    .validate(input)
+                            })
+                            .help("To long multisig address (special case, include since)"),
+                    )
+                    .arg(arg::capacity().required(true))
+                    .arg(arg::to_data())
+                    .arg(arg::to_data_path())
+                    .arg(arg_tx_file.clone()),
+                SubCommand::with_name("add-signature")
+                    .about("Add signature")
+                    .arg(
+                        Arg::with_name("lock-arg")
+                            .long("lock-arg")
+                            .takes_value(true)
+                            .required(true)
+                            .validator(|input| match HexParser.parse(&input) {
+                                Ok(ref data) if data.len() == 20 || data.len() == 28 => Ok(()),
+                                Ok(ref data) => Err(format!("invalid data length: {}", data.len())),
+                                Err(err) => Err(err.to_string()),
+                            })
+                            .help("The lock_arg of input lock script (20 bytes or 28 bytes)"),
+                    )
+                    .arg(
+                        Arg::with_name("signature")
+                            .long("signature")
+                            .takes_value(true)
+                            .required(true)
+                            .validator(|input| match HexParser.parse(&input) {
+                                Ok(ref data) if data.len() == SECP_SIGNATURE_SIZE => Ok(()),
+                                Ok(ref data) => Err(format!("invalid data length: {}", data.len())),
+                                Err(err) => Err(err.to_string()),
+                            })
+                            .help("The signature"),
+                    )
+                    .arg(arg_tx_file.clone()),
+                SubCommand::with_name("info")
+                    .about("Show detail of this multisig transaction (capacity, tx-fee, etc.)")
+                    .arg(arg_tx_file.clone()),
+                SubCommand::with_name("sign-inputs")
+                    .about("Sign all sighash/multisig inputs in this transaction")
+                    .arg(arg::privkey_path().required_unless(arg::from_account().b.name))
+                    .arg(arg::from_account().required_unless(arg::privkey_path().b.name))
+                    .arg(arg_tx_file.clone())
+                    .arg(
+                        Arg::with_name("add-signatures")
+                            .long("add-signatures")
+                            .help("Sign and add signatures"),
+                    ),
+                SubCommand::with_name("send")
+                    .about("Send multisig transaction")
+                    .arg(arg_tx_file.clone())
+                    .arg(
+                        Arg::with_name("max-tx-fee")
+                            .long("max-tx-fee")
+                            .takes_value(true)
+                            .default_value("1.0")
+                            .validator(|input| CapacityParser.validate(input))
+                            .help("Max transaction fee (unit: CKB)"),
+                    ),
+                SubCommand::with_name("build-multisig-address")
+                    .about(
+                        "Build multisig address with multisig config and since(optional) argument",
+                    )
+                    .arg(arg_sighash_address.clone())
+                    .arg(arg_require_first_n.clone())
+                    .arg(arg_threshold.clone())
+                    .arg(arg_since_absolute_epoch.clone()),
+            ])
+    }
+}
+
+impl<'a> CliSubCommand for TxSubCommand<'a> {
+    fn process(
+        &mut self,
+        matches: &ArgMatches,
+        format: OutputFormat,
+        color: bool,
+        debug: bool,
+    ) -> Result<String, String> {
+        let network = get_network_type(self.rpc_client)?;
+
+        match matches.subcommand() {
+            ("init", Some(m)) => {
+                let tx_file_opt: Option<PathBuf> =
+                    FilePathParser::new(false).from_matches_opt(m, "tx-file", false)?;
+                let helper = TxHelper::default();
+                let repr = ReprTxHelper::new(helper, network);
+
+                if let Some(tx_file) = tx_file_opt {
+                    let mut file = fs::File::create(&tx_file).map_err(|err| err.to_string())?;
+                    let content =
+                        serde_json::to_string_pretty(&repr).map_err(|err| err.to_string())?;
+                    file.write_all(content.as_bytes())
+                        .map_err(|err| err.to_string())?;
+                    Ok(String::from("ok"))
+                } else {
+                    Ok(repr.render(format, color))
+                }
+            }
+            ("clear-field", Some(m)) => {
+                let tx_file: PathBuf = FilePathParser::new(true).from_matches(m, "tx-file")?;
+                let field = m.value_of("field").unwrap();
+                modify_tx_file(&tx_file, network, |helper| {
+                    match field {
+                        "inputs" => helper.clear_inputs(),
+                        "outputs" => helper.clear_outputs(),
+                        "signatures" => helper.clear_signatures(),
+                        _ => panic!("Invalid clear field: {}", field),
+                    }
+                    Ok(())
+                })?;
+                Ok(String::from("ok"))
+            }
+            ("add-input", Some(m)) => {
+                let tx_file: PathBuf = FilePathParser::new(true).from_matches(m, "tx-file")?;
+                let tx_hash: H256 =
+                    FixedHashParser::<H256>::default().from_matches(m, "tx-hash")?;
+                let index: u32 = FromStrParser::<u32>::default().from_matches(m, "index")?;
+                let since_absolute_epoch_opt: Option<u64> = FromStrParser::<u64>::default()
+                    .from_matches_opt(m, "since-absolute-epoch", false)?;
+
+                let genesis_info = get_genesis_info(&self.genesis_info, self.rpc_client)?;
+                let out_point = OutPoint::new_builder()
+                    .tx_hash(tx_hash.pack())
+                    .index(index.pack())
+                    .build();
+                let get_live_cell = |out_point, with_data| {
+                    get_live_cell(self.rpc_client, out_point, with_data).map(|(output, _)| output)
+                };
+                modify_tx_file(&tx_file, network, |helper| {
+                    helper.add_input(
+                        out_point,
+                        since_absolute_epoch_opt,
+                        get_live_cell,
+                        &genesis_info,
+                    )
+                })?;
+
+                Ok(String::from("ok"))
+            }
+            ("add-output", Some(m)) => {
+                let tx_file: PathBuf = FilePathParser::new(true).from_matches(m, "tx-file")?;
+                let capacity: u64 = CapacityParser.from_matches(m, "capacity")?;
+                let to_sighash_address_opt: Option<Address> = AddressParser::new_sighash()
+                    .from_matches_opt(m, "to-sighash-address", false)?;
+                let to_short_multisig_address_opt: Option<Address> = AddressParser::new_multisig()
+                    .from_matches_opt(m, "to-short-multisig-address", false)?;
+                let to_long_multisig_address_opt: Option<Address> = AddressParser::default()
+                    .set_full_type(MULTISIG_TYPE_HASH)
+                    .from_matches_opt(m, "to-long-multisig-address", false)?;
+
+                let to_data = get_to_data(m)?;
+                check_capacity(capacity, to_data.len())?;
+                if let Some(address) = to_long_multisig_address_opt.as_ref() {
+                    let payload = address.payload();
+                    if payload.args().len() != 28 {
+                        return Err(format!(
+                            "Invalid address lock_arg length({}) for `to-long-multisig-address`",
+                            payload.args().len()
+                        ));
+                    }
+                }
+                let lock_script = to_sighash_address_opt
+                    .or_else(|| to_short_multisig_address_opt)
+                    .or_else(|| to_long_multisig_address_opt)
+                    .map(|address| Script::from(address.payload()))
+                    .ok_or_else(|| "missing target address".to_string())?;
+                let output = CellOutput::new_builder()
+                    .capacity(Capacity::shannons(capacity).pack())
+                    .lock(lock_script)
+                    .build();
+
+                modify_tx_file(&tx_file, network, |helper| {
+                    helper.add_output(output, to_data);
+                    Ok(())
+                })?;
+
+                Ok(String::from("ok"))
+            }
+            ("add-signature", Some(m)) => {
+                let tx_file: PathBuf = FilePathParser::new(true).from_matches(m, "tx-file")?;
+                let lock_arg: Bytes = HexParser.from_matches(m, "lock-arg")?;
+                let signature: Bytes = HexParser.from_matches(m, "signature")?;
+
+                modify_tx_file(&tx_file, network, |helper| {
+                    helper.add_signature(lock_arg, signature)
+                })?;
+                Ok(String::from("ok"))
+            }
+            ("add-multisig-config", Some(m)) => {
+                let tx_file: PathBuf = FilePathParser::new(false).from_matches(m, "tx-file")?;
+                let sighash_addresses: Vec<Address> = AddressParser::default()
+                    .set_network(network)
+                    .set_short(CodeHashIndex::Sighash)
+                    .from_matches_vec(m, "sighash-address")?;
+                let require_first_n: u8 =
+                    FromStrParser::<u8>::default().from_matches(m, "require-first-n")?;
+                let threshold: u8 = FromStrParser::<u8>::default().from_matches(m, "threshold")?;
+
+                let sighash_addresses = sighash_addresses
+                    .into_iter()
+                    .map(|address| address.payload().clone())
+                    .collect::<Vec<_>>();
+                let cfg = MultisigConfig::new_with(sighash_addresses, require_first_n, threshold)?;
+                modify_tx_file(&tx_file, network, |helper| {
+                    helper.add_multisig_config(cfg);
+                    Ok(())
+                })?;
+                Ok(String::from("ok"))
+            }
+            ("info", Some(m)) => {
+                let tx_file: PathBuf = FilePathParser::new(false).from_matches(m, "tx-file")?;
+
+                let mut live_cell_cache: HashMap<(OutPoint, bool), (CellOutput, Bytes)> =
+                    Default::default();
+                let mut get_live_cell = |out_point: OutPoint, with_data: bool| {
+                    get_live_cell_with_cache(
+                        &mut live_cell_cache,
+                        self.rpc_client,
+                        out_point,
+                        with_data,
+                    )
+                };
+
+                let file = fs::File::open(tx_file).map_err(|err| err.to_string())?;
+                let repr: ReprTxHelper =
+                    serde_json::from_reader(&file).map_err(|err| err.to_string())?;
+                let helper = TxHelper::try_from(repr)?;
+                let tx = helper.transaction();
+
+                let mut input_total = 0;
+                for input in tx.inputs().into_iter() {
+                    let (output, data) = get_live_cell(input.previous_output(), true)?;
+                    let capacity: u64 = output.capacity().unpack();
+                    input_total += capacity;
+
+                    let type_script_empty = output.type_().to_opt().is_none();
+                    let prefix = if helper
+                        .signatures()
+                        .contains_key(&output.lock().args().raw_data())
+                    {
+                        "input(signed)"
+                    } else {
+                        "input"
+                    };
+                    print_cell_info(
+                        prefix,
+                        network,
+                        output.lock(),
+                        capacity,
+                        data.len(),
+                        type_script_empty,
+                    );
+                }
+
+                let mut output_total = 0;
+                for (output, data) in tx.outputs().into_iter().zip(tx.outputs_data().into_iter()) {
+                    let capacity: u64 = output.capacity().unpack();
+                    output_total += capacity;
+                    let data_len = data.raw_data().len();
+                    let type_script_empty = output.type_().is_none();
+                    print_cell_info(
+                        "output",
+                        network,
+                        output.lock(),
+                        capacity,
+                        data_len,
+                        type_script_empty,
+                    );
+                }
+                let tx_fee_string = if input_total >= output_total {
+                    format!("{:#}", HumanCapacity(input_total - output_total))
+                } else {
+                    format!("-{:#}", HumanCapacity(output_total - input_total))
+                };
+
+                let resp = serde_json::json!({
+                    "input_total": format!("{:#}", HumanCapacity(input_total)),
+                    "output_total": format!("{:#}", HumanCapacity(output_total)),
+                    "tx_fee": tx_fee_string,
+                });
+                Ok(resp.render(format, color))
+            }
+            ("sign-inputs", Some(m)) => {
+                let tx_file: PathBuf = FilePathParser::new(true).from_matches(m, "tx-file")?;
+                let privkey_opt: Option<PrivkeyWrapper> =
+                    PrivkeyPathParser.from_matches_opt(m, "privkey-path", false)?;
+                let account_opt: Option<H160> = FixedHashParser::<H160>::default()
+                    .from_matches_opt(m, "from-account", false)?;
+
+                let signer = if let Some(privkey) = privkey_opt {
+                    get_privkey_signer(privkey)
+                } else {
+                    let password = read_password(false, None)?;
+                    let account = account_opt.unwrap();
+                    let key_store = self.key_store.clone();
+                    get_keystore_signer(key_store, account, password)
+                };
+
+                let mut live_cell_cache: HashMap<(OutPoint, bool), (CellOutput, Bytes)> =
+                    Default::default();
+                let get_live_cell = |out_point: OutPoint, with_data: bool| {
+                    get_live_cell_with_cache(
+                        &mut live_cell_cache,
+                        self.rpc_client,
+                        out_point,
+                        with_data,
+                    )
+                    .map(|(output, _)| output)
+                };
+
+                let signatures = modify_tx_file(&tx_file, network, |helper| {
+                    let signatures = helper.sign_inputs(signer, get_live_cell)?;
+                    if m.is_present("add-signatures") {
+                        for (lock_arg, signature) in signatures.clone() {
+                            helper.add_signature(lock_arg, signature)?;
+                        }
+                    }
+                    Ok(signatures)
+                })?;
+                let resp = signatures
+                    .into_iter()
+                    .map(|(lock_arg, signature)| {
+                        serde_json::json!({
+                            "lock-arg": format!("0x{}", hex_string(&lock_arg).unwrap()),
+                            "signature": format!("0x{}", hex_string(&signature).unwrap()),
+                        })
+                    })
+                    .collect::<Vec<_>>();
+                Ok(resp.render(format, color))
+            }
+            ("send", Some(m)) => {
+                let tx_file: PathBuf = FilePathParser::new(false).from_matches(m, "tx-file")?;
+                let max_tx_fee: u64 = CapacityParser.from_matches(m, "max-tx-fee")?;
+
+                let mut live_cell_cache: HashMap<(OutPoint, bool), (CellOutput, Bytes)> =
+                    Default::default();
+                let mut get_live_cell = |out_point: OutPoint, with_data: bool| {
+                    get_live_cell_with_cache(
+                        &mut live_cell_cache,
+                        self.rpc_client,
+                        out_point,
+                        with_data,
+                    )
+                    .map(|(output, _)| output)
+                };
+
+                let file = fs::File::open(tx_file).map_err(|err| err.to_string())?;
+                let repr: ReprTxHelper =
+                    serde_json::from_reader(&file).map_err(|err| err.to_string())?;
+                let helper = TxHelper::try_from(repr)?;
+
+                let (input_total, output_total) = helper.check_tx(&mut get_live_cell)?;
+                let tx_fee = input_total - output_total;
+                if tx_fee > max_tx_fee {
+                    return Err(format!(
+                        "Too much transaction fee: {:#}, max: {:#}",
+                        HumanCapacity(tx_fee),
+                        HumanCapacity(max_tx_fee),
+                    ));
+                }
+                let tx = helper.build_tx(&mut get_live_cell)?;
+                let rpc_tx = json_types::Transaction::from(tx.data());
+                if debug {
+                    println!("[send transaction]:\n{}", rpc_tx.render(format, color));
+                }
+                let resp = self
+                    .rpc_client
+                    .send_transaction(tx.data())
+                    .map_err(|err| format!("Send transaction error: {}", err))?;
+                Ok(resp.render(format, color))
+            }
+            ("build-multisig-address", Some(m)) => {
+                let sighash_addresses: Vec<Address> = AddressParser::default()
+                    .set_network(network)
+                    .set_short(CodeHashIndex::Sighash)
+                    .from_matches_vec(m, "sighash-address")?;
+                let require_first_n: u8 =
+                    FromStrParser::<u8>::default().from_matches(m, "require-first-n")?;
+                let threshold: u8 = FromStrParser::<u8>::default().from_matches(m, "threshold")?;
+                let since_absolute_epoch_opt: Option<u64> = FromStrParser::<u64>::default()
+                    .from_matches_opt(m, "since-absolute-epoch", false)?;
+
+                let sighash_addresses = sighash_addresses
+                    .into_iter()
+                    .map(|address| address.payload().clone())
+                    .collect::<Vec<_>>();
+                let cfg = MultisigConfig::new_with(sighash_addresses, require_first_n, threshold)?;
+                let address_payload = cfg.to_address_payload(since_absolute_epoch_opt);
+                let lock_script = Script::from(&address_payload);
+                let resp = serde_json::json!({
+                    "mainnet": Address::new(NetworkType::Mainnet, address_payload.clone()).to_string(),
+                    "testnet": Address::new(NetworkType::Testnet, address_payload.clone()).to_string(),
+                    "lock-arg": format!("0x{}", hex_string(address_payload.args().as_ref()).unwrap()),
+                    "lock-hash": format!("{:#x}", lock_script.calc_script_hash())
+                });
+                Ok(resp.render(format, color))
+            }
+            _ => Err(matches.usage().to_owned()),
+        }
+    }
+}
+
+fn print_cell_info(
+    prefix: &str,
+    network: NetworkType,
+    lock: packed::Script,
+    capacity: u64,
+    data_len: usize,
+    type_script_empty: bool,
+) {
+    let address_payload = AddressPayload::from(lock);
+    let lock_kind = if address_payload.code_hash() == MULTISIG_TYPE_HASH.pack() {
+        if address_payload.args().len() == 20 {
+            "multisig without since"
+        } else {
+            "multisig with since"
+        }
+    } else {
+        "sighash(secp)"
+    };
+    let address = Address::new(network, address_payload);
+    let type_script_status = if type_script_empty { "none" } else { "some" };
+    println!(
+        "[{}] {} => {}, (data-length: {}, type-script: {}, lock-kind: {})",
+        prefix,
+        address,
+        HumanCapacity(capacity),
+        data_len,
+        type_script_status,
+        lock_kind,
+    );
+}
+
+fn serialize_signature(
+    signature: &secp256k1::recovery::RecoverableSignature,
+) -> [u8; SECP_SIGNATURE_SIZE] {
+    let (recov_id, data) = signature.serialize_compact();
+    let mut signature_bytes = [0u8; 65];
+    signature_bytes[0..64].copy_from_slice(&data[0..64]);
+    signature_bytes[64] = recov_id.to_i32() as u8;
+    signature_bytes
+}
+
+type SignerFn = Box<dyn FnMut(&HashSet<H160>, &H256) -> Result<Option<[u8; 65]>, String>>;
+
+fn get_privkey_signer(privkey: PrivkeyWrapper) -> SignerFn {
+    let pubkey = secp256k1::PublicKey::from_secret_key(&SECP256K1, &privkey);
+    let lock_arg = H160::from_slice(&blake2b_256(&pubkey.serialize()[..])[0..20])
+        .expect("Generate hash(H160) from pubkey failed");
+    Box::new(move |lock_args: &HashSet<H160>, message: &H256| {
+        if lock_args.contains(&lock_arg) {
+            if message == &SIGHASH_TYPE_HASH {
+                Ok(Some([0u8; 65]))
+            } else {
+                let message = secp256k1::Message::from_slice(message.as_bytes())
+                    .expect("Convert to secp256k1 message failed");
+                let signature = SECP256K1.sign_recoverable(&message, &privkey);
+                Ok(Some(serialize_signature(&signature)))
+            }
+        } else {
+            Ok(None)
+        }
+    })
+}
+
+fn get_keystore_signer(key_store: KeyStore, account: H160, password: String) -> SignerFn {
+    Box::new(move |lock_args: &HashSet<H160>, message: &H256| {
+        if lock_args.contains(&account) {
+            if message == &SIGHASH_TYPE_HASH {
+                Ok(Some([0u8; 65]))
+            } else {
+                key_store
+                    .sign_recoverable_with_password(&account, None, message, password.as_bytes())
+                    .map(|signature| Some(serialize_signature(&signature)))
+                    .map_err(|err| err.to_string())
+            }
+        } else {
+            Ok(None)
+        }
+    })
+}
+
+fn modify_tx_file<T, F: FnOnce(&mut TxHelper) -> Result<T, String>>(
+    path: &PathBuf,
+    network: NetworkType,
+    func: F,
+) -> Result<T, String> {
+    let file = fs::File::open(path).map_err(|err| err.to_string())?;
+    let repr: ReprTxHelper = serde_json::from_reader(&file).map_err(|err| err.to_string())?;
+    let mut helper = TxHelper::try_from(repr)?;
+
+    let result = func(&mut helper)?;
+
+    let repr = ReprTxHelper::new(helper, network);
+    let mut file = fs::File::create(path).map_err(|err| err.to_string())?;
+    let content = serde_json::to_string_pretty(&repr).map_err(|err| err.to_string())?;
+    file.write_all(content.as_bytes())
+        .map_err(|err| err.to_string())?;
+    Ok(result)
+}
+
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Debug)]
+#[serde(deny_unknown_fields)]
+struct ReprTxHelper {
+    transaction: json_types::Transaction,
+    multisig_configs: HashMap<H160, ReprMultisigConfig>,
+    signatures: HashMap<JsonBytes, Vec<JsonBytes>>,
+}
+
+impl ReprTxHelper {
+    fn new(tx: TxHelper, network: NetworkType) -> Self {
+        ReprTxHelper {
+            transaction: tx.transaction().data().into(),
+            multisig_configs: tx
+                .multisig_configs()
+                .iter()
+                .map(|(lock_arg, cfg)| {
+                    (
+                        lock_arg.clone(),
+                        ReprMultisigConfig::new(cfg.clone(), network),
+                    )
+                })
+                .collect(),
+            signatures: tx
+                .signatures()
+                .iter()
+                .map(|(lock_arg, signatures)| {
+                    (
+                        JsonBytes::from_bytes(lock_arg.clone()),
+                        signatures
+                            .iter()
+                            .cloned()
+                            .map(JsonBytes::from_bytes)
+                            .collect(),
+                    )
+                })
+                .collect(),
+        }
+    }
+}
+
+impl TryFrom<ReprTxHelper> for TxHelper {
+    type Error = String;
+    fn try_from(repr: ReprTxHelper) -> Result<Self, Self::Error> {
+        let transaction = packed::Transaction::from(repr.transaction).into_view();
+        let multisig_configs = repr
+            .multisig_configs
+            .into_iter()
+            .map(|(_, repr_cfg)| MultisigConfig::try_from(repr_cfg))
+            .collect::<Result<Vec<_>, String>>()?;
+        let signatures: HashMap<Bytes, HashSet<Bytes>> = repr
+            .signatures
+            .into_iter()
+            .map(|(lock_arg, signatures)| {
+                (
+                    lock_arg.into_bytes(),
+                    signatures.into_iter().map(JsonBytes::into_bytes).collect(),
+                )
+            })
+            .collect();
+
+        let mut tx_helper = TxHelper::new(transaction);
+        for cfg in multisig_configs {
+            tx_helper.add_multisig_config(cfg);
+        }
+        for (lock_arg, sub_signatures) in signatures {
+            for sub_signature in sub_signatures {
+                tx_helper.add_signature(lock_arg.clone(), sub_signature)?;
+            }
+        }
+        Ok(tx_helper)
+    }
+}
+
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Debug)]
+#[serde(deny_unknown_fields)]
+struct ReprMultisigConfig {
+    sighash_addresses: Vec<String>,
+    require_first_n: u8,
+    threshold: u8,
+}
+
+impl ReprMultisigConfig {
+    fn new(cfg: MultisigConfig, network: NetworkType) -> Self {
+        let sighash_addresses = cfg
+            .sighash_addresses()
+            .iter()
+            .map(|payload| Address::new(network, payload.clone()).to_string())
+            .collect();
+        ReprMultisigConfig {
+            sighash_addresses,
+            require_first_n: cfg.require_first_n(),
+            threshold: cfg.threshold(),
+        }
+    }
+}
+
+impl TryFrom<ReprMultisigConfig> for MultisigConfig {
+    type Error = String;
+    fn try_from(repr: ReprMultisigConfig) -> Result<Self, Self::Error> {
+        let sighash_addresses = repr
+            .sighash_addresses
+            .into_iter()
+            .map(|address_string| {
+                Address::from_str(&address_string).map(|addr| addr.payload().clone())
+            })
+            .collect::<Result<Vec<_>, String>>()?;
+        MultisigConfig::new_with(sighash_addresses, repr.require_first_n, repr.threshold)
+    }
+}

--- a/src/utils/arg_parser.rs
+++ b/src/utils/arg_parser.rs
@@ -236,6 +236,7 @@ impl ArgParser<PathBuf> for DirPathParser {
     }
 }
 
+#[derive(Clone)]
 pub struct PrivkeyWrapper(pub secp256k1::SecretKey);
 
 // For security purpose
@@ -318,7 +319,6 @@ pub enum AddressPayloadOption {
     Full(Option<H256>),
     #[allow(dead_code)]
     FullData(Option<H256>),
-    #[allow(dead_code)]
     FullType(Option<H256>),
 }
 
@@ -339,6 +339,19 @@ impl AddressParser {
         payload: Option<AddressPayloadOption>,
     ) -> AddressParser {
         AddressParser { network, payload }
+    }
+
+    pub fn new_sighash() -> Self {
+        AddressParser {
+            network: None,
+            payload: Some(AddressPayloadOption::Short(Some(CodeHashIndex::Sighash))),
+        }
+    }
+    pub fn new_multisig() -> Self {
+        AddressParser {
+            network: None,
+            payload: Some(AddressPayloadOption::Short(Some(CodeHashIndex::Multisig))),
+        }
     }
 
     pub fn set_network(&mut self, network: NetworkType) -> &mut Self {
@@ -366,7 +379,6 @@ impl AddressParser {
         self.payload = Some(AddressPayloadOption::FullData(Some(code_hash)));
         self
     }
-    #[allow(dead_code)]
     pub fn set_full_type(&mut self, code_hash: H256) -> &mut Self {
         self.payload = Some(AddressPayloadOption::FullType(Some(code_hash)));
         self


### PR DESCRIPTION
Add a top level sub-command `tx`, which help you craft and send complex transaction with sighash/multisig lock script.
```
CKB> tx --help
Handle common sighash/multisig transaction

SUBCOMMANDS:
    init                      Init a common (sighash/multisig) transaction
    add-multisig-config       Add multisig config
    clear-field               Remove all field items in transaction
    add-input                 Add cell input (with secp/multisig lock)
    add-output                Add cell output
    add-signature             Add signature
    info                      Show detail of this multisig transaction (capacity, tx-fee, etc.)
    sign-inputs               Sign all sighash/multisig inputs in this transaction
    send                      Send multisig transaction
    build-multisig-address    Build multisig address with multisig config and since(optional) argument
```

### A typical usage [example](https://github.com/nervosnetwork/ckb-cli/wiki/Usage-Examples)
``` shell
# Build a multisig address with absolute epoch since
CKB> tx build-multisig-address --sighash-address ckt1qyqdfjzl8ju2vfwjtl4mttx6me09hayzfldq8m3a0y --since-absolute-epoch 61
lock-arg: 0x9e2578fd0679a24726b7930fffb99a721c26f8db3d00000000010020
lock-hash: 0x0486e7ec2a98b7a19a9f9fcabd8b58f046a36353677663330e512ec13576ea82
mainnet: ckb1q3w9q60tppt7l3j7r09qcp7lxnp3vcanvgha8pmvsa3jplykxn3238390r7sv7dzgunt0yc0l7ue5usuymudk0gqqqqqqqgqyqlm8p7r
testnet: ckt1q3w9q60tppt7l3j7r09qcp7lxnp3vcanvgha8pmvsa3jplykxn3238390r7sv7dzgunt0yc0l7ue5usuymudk0gqqqqqqqgqyqsyxc6n

# Transfer 20000 capacity to the multisig address
CKB> wallet transfer --from-account 0xda648442dbb7347e467d1d09da13e5cd3a0ef0e1 --to-address ckt1q3w9q60tppt7l3j7r09qcp7lxnp3vcanvgha8pmvsa3jplykxn3238390r7sv7dzgunt0yc0l7ue5usuymudk0gqqqqqqqgqyqsyxc6n --capacity 20000 --tx-fee 0.0001
Password:
0x1aefd4b0b8e542bbc0f0e9e7f8109646feeb39a087f460aab108dd9e64b274f9

# Query the capacity of the multisig address
CKB> wallet get-capacity --address ckt1q3w9q60tppt7l3j7r09qcp7lxnp3vcanvgha8pmvsa3jplykxn3238390r7sv7dzgunt0yc0l7ue5usuymudk0gqqqqqqqgqyqsyxc6n
total: 20000.0 (CKB)

# Initialize a complex transaction
CKB> tx init --tx-file ../tx.json
ok
cat ../tx.json
{
  "transaction": {
    "version": "0x0",
    "cell_deps": [],
    "header_deps": [],
    "inputs": [],
    "outputs": [],
    "witnesses": [],
    "outputs_data": []
  },
  "multisig_configs": {},
  "signatures": {}
}

# Query the live cell of the multisig address
CKB> wallet get-live-cells --address ckt1q3w9q60tppt7l3j7r09qcp7lxnp3vcanvgha8pmvsa3jplykxn3238390r7sv7dzgunt0yc0l7ue5usuymudk0gqqqqqqqgqyqsyxc6n
current_capacity: 20000.0 (CKB)
current_count: 1
live_cells:
  - capacity: 20000.0 (CKB)
    data_bytes: 0
    index:
      output_index: 0
      tx_index: 1
    lock_hash: 0x0486e7ec2a98b7a19a9f9fcabd8b58f046a36353677663330e512ec13576ea82
    mature: true
    number: 56207
    tx_hash: 0x1aefd4b0b8e542bbc0f0e9e7f8109646feeb39a087f460aab108dd9e64b274f9
    tx_index: 0
    type_hashes: ~
total_capacity: 20000.0 (CKB)
total_count: 1

# Add a multisig config of the mutlisig address
CKB> tx add-multisig-config --sighash-address ckt1qyqdfjzl8ju2vfwjtl4mttx6me09hayzfldq8m3a0y --tx-file ../tx.json
ok

# Add the live cell as input to the transaction
CKB> tx add-input --tx-hash 0x1aefd4b0b8e542bbc0f0e9e7f8109646feeb39a087f460aab108dd9e64b274f9 --index 0 --tx-file ../tx.json
ok

# Add a output to the transaction
CKB> tx add-output --to-sighash-address ckt1qyqg7zchpds6lv3v0nr36z2msu2x9a5lkhrq7kvyww --capacity 19999.9999 --tx-file ../tx.json
ok

# Show details of the transaction
CKB> tx info --tx-file ../tx.json
[input] ckt1q3w9q60tppt7l3j7r09qcp7lxnp3vcanvgha8pmvsa3jplykxn3238390r7sv7dzgunt0yc0l7ue5usuymudk0gqqqqqqqgqyqsyxc6n => 20000.0, (data-length: 0, type-script: none, lock-kind: multisig with since)
[output] ckt1qyqg7zchpds6lv3v0nr36z2msu2x9a5lkhrq7kvyww => 19999.9999, (data-length: 0, type-script: none, lock-kind: sighash(secp))
input_total: 20000.0 (CKB)
output_total: 19999.9999 (CKB)
tx_fee: 0.0001 (CKB)

# Sign input of this transaction and add it to tx.json, the from-account argument is the owner of the multisig address
CKB> tx sign-inputs --from-account 0xd4c85f3cb8a625d25febb5acdade5e5bf4824fda --add-signatures --tx-file ../tx.json
Password:
- lock-arg: 0x9e2578fd0679a24726b7930fffb99a721c26f8db3d00000000010020
  signature: 0x0c44c12638277ffa6eafeac55cd918932f1cdbcfd4df413c11e8fb5b48f41ba22f738bad494e63d78c2bf2a4e0f4676db1d48d37f3d872d28bac70b2ef5a567a01

# Send this transaction
CKB> tx send --tx-file ../tx.json
0x9245ecb248ec88991a80dcb8fee3932fe694ddc4c7ee061fb38f2e27befacf47

# Query the target address
CKB> wallet get-capacity --address ckt1qyqg7zchpds6lv3v0nr36z2msu2x9a5lkhrq7kvyww
total: 19999.9999 (CKB)
```