### PR TITLE
feat: Add a global flag `--wait-for-sync`

### DIFF
--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -347,7 +347,6 @@ impl InteractiveEnv {
                         Some(genesis_info),
                         self.index_dir.clone(),
                         self.index_controller.clone(),
-                        true,
                     )
                     .process(&sub_matches, format, color, debug)?;
                     println!("{}", output);

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,13 +92,13 @@ fn main() -> Result<(), io::Error> {
     let color = ColorWhen::new(!matches.is_present("no-color")).color();
     let debug = matches.is_present("debug");
 
-    {
-        let wait_for_sync = matches.is_present("wait-for-sync");
-        if wait_for_sync {
-            if let Err(err) = sync_to_tip(&mut rpc_client, &index_dir) {
-                eprintln!("Synchronize error: {}", err);
-                process::exit(1);
-            }
+    // When flag `--wait-for-sync` given, we have to ensure that the index-store synchronizes
+    // to the tip before executing the command.
+    let wait_for_sync = matches.is_present("wait-for-sync");
+    if wait_for_sync {
+        if let Err(err) = sync_to_tip(&mut rpc_client, &index_dir) {
+            eprintln!("Synchronize error: {}", err);
+            process::exit(1);
         }
     }
 
@@ -142,7 +142,6 @@ fn main() -> Result<(), io::Error> {
                 None,
                 index_dir.clone(),
                 index_controller.clone(),
-                false,
             )
             .process(&sub_matches, output_format, color, debug)
         }),

--- a/src/subcommands/wallet/mod.rs
+++ b/src/subcommands/wallet/mod.rs
@@ -49,7 +49,6 @@ pub struct WalletSubCommand<'a> {
     genesis_info: Option<GenesisInfo>,
     index_dir: PathBuf,
     index_controller: IndexController,
-    interactive: bool,
 }
 
 impl<'a> WalletSubCommand<'a> {
@@ -59,7 +58,6 @@ impl<'a> WalletSubCommand<'a> {
         genesis_info: Option<GenesisInfo>,
         index_dir: PathBuf,
         index_controller: IndexController,
-        interactive: bool,
     ) -> WalletSubCommand<'a> {
         WalletSubCommand {
             rpc_client,
@@ -67,7 +65,6 @@ impl<'a> WalletSubCommand<'a> {
             genesis_info,
             index_dir,
             index_controller,
-            interactive,
         }
     }
 
@@ -90,10 +87,6 @@ impl<'a> WalletSubCommand<'a> {
     where
         F: FnOnce(IndexDatabase) -> T,
     {
-        if !self.interactive {
-            return Err("ERROR: This is an interactive mode only sub-command".to_string());
-        }
-
         let network_type = get_network_type(self.rpc_client)?;
         let genesis_info = self.genesis_info()?;
         let genesis_hash: H256 = genesis_info.header().hash().unpack();


### PR DESCRIPTION
https://github.com/nervosnetwork/ckb-cli/issues/199

`--wait-for-sync` is a global flag, indicates a requirement that the command must not be executing unless the index-store synchronize to tip before executing the command.