### PR TITLE
feat: Allow import keystore exported from Neuron

### DIFF
--- a/ckb-sdk/src/wallet/keystore/error.rs
+++ b/ckb-sdk/src/wallet/keystore/error.rs
@@ -14,6 +14,9 @@ pub enum Error {
     #[fail(display = "Key mismatch, got {:x}, expected: {:x}", got, expected)]
     KeyMismatch { got: H160, expected: H160 },
 
+    #[fail(display = "Key already exists {:x}", _0)]
+    KeyExists(H160),
+
     #[fail(display = "Wrong password for {:x}", _0)]
     WrongPassword(H160),
 

--- a/ckb-sdk/src/wallet/keystore/mod.rs
+++ b/ckb-sdk/src/wallet/keystore/mod.rs
@@ -126,9 +126,13 @@ impl KeyStore {
         new_password: &[u8],
     ) -> Result<H160, Error> {
         let key = Key::from_json(data, password)?;
-        let filepath = self.storage.store_key(key.filename(), &key, new_password)?;
-        self.files.insert(key.hash160().clone(), filepath);
-        Ok(key.hash160().clone())
+        if self.files.contains_key(key.hash160()) {
+            Err(Error::KeyExists(key.hash160().clone()))
+        } else {
+            let filepath = self.storage.store_key(key.filename(), &key, new_password)?;
+            self.files.insert(key.hash160().clone(), filepath);
+            Ok(key.hash160().clone())
+        }
     }
     pub fn import_secp_key(
         &mut self,
@@ -136,14 +140,22 @@ impl KeyStore {
         password: &[u8],
     ) -> Result<H160, Error> {
         let key = Key::new(MasterPrivKey::from_secp_key(key));
-        let filepath = self.storage.store_key(key.filename(), &key, password)?;
-        self.files.insert(key.hash160().clone(), filepath);
-        Ok(key.hash160().clone())
+        if self.files.contains_key(key.hash160()) {
+            Err(Error::KeyExists(key.hash160().clone()))
+        } else {
+            let filepath = self.storage.store_key(key.filename(), &key, password)?;
+            self.files.insert(key.hash160().clone(), filepath);
+            Ok(key.hash160().clone())
+        }
     }
     pub fn import_key(&mut self, key: &Key, password: &[u8]) -> Result<H160, Error> {
-        let filepath = self.storage.store_key(key.filename(), key, password)?;
-        self.files.insert(key.hash160().clone(), filepath);
-        Ok(key.hash160().clone())
+        if self.files.contains_key(key.hash160()) {
+            Err(Error::KeyExists(key.hash160().clone()))
+        } else {
+            let filepath = self.storage.store_key(key.filename(), key, password)?;
+            self.files.insert(key.hash160().clone(), filepath);
+            Ok(key.hash160().clone())
+        }
     }
     pub fn export(
         &self,

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -153,7 +153,7 @@ impl InteractiveEnv {
                         }
                         Ok(false) => {}
                         Err(err) => {
-                            eprintln!("{}", err.to_string());
+                            eprintln!("{}", err);
                         }
                     }
                     rl.add_history_entry(line.as_str());


### PR DESCRIPTION
### Usage example
``` shell
CKB> account import-keystore --help
Import key from encrypted keystore json file and create a new account.

USAGE:
    account import-keystore --path <path>

OPTIONS:
        --path <path>    The keystore file path (json format)


CKB> account import-keystore --path xxx.json
Decrypt password:                                                   
Password:                                         
Repeat password: 
```