### PR TITLE
perf: Speed up sync index database

### DIFF
--- a/ckb-index/src/index/mod.rs
+++ b/ckb-index/src/index/mod.rs
@@ -303,8 +303,10 @@ impl<'a> IndexDatabase<'a> {
         };
 
         let mut txn = RocksTxn::new(self.db, self.cf);
-        for block in blocks {
-            let block_delta_info = BlockDeltaInfo::from_block(&block, &txn);
+        let blocks_len = blocks.len();
+        for (idx, block) in blocks.into_iter().enumerate() {
+            let clear_old = idx + 1 == blocks_len;
+            let block_delta_info = BlockDeltaInfo::from_block(&block, &txn, clear_old);
             let number = block_delta_info.number();
             let hash = block_delta_info.hash();
             let result = block_delta_info.apply(&mut txn, self.enable_explorer);

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -12,12 +12,13 @@ use rustyline::{Cmd, CompletionType, Config, EditMode, Editor, KeyPress};
 use serde_json::json;
 
 use crate::subcommands::{
-    AccountSubCommand, CliSubCommand, IndexController, IndexRequest, MockTxSubCommand,
-    MoleculeSubCommand, RpcSubCommand, TxSubCommand, UtilSubCommand, WalletSubCommand,
+    AccountSubCommand, CliSubCommand, MockTxSubCommand, MoleculeSubCommand, RpcSubCommand,
+    TxSubCommand, UtilSubCommand, WalletSubCommand,
 };
 use crate::utils::{
     completer::CkbCompleter,
     config::GlobalConfig,
+    index::{IndexController, IndexRequest},
     other::{check_alerts, get_network_type, index_dirname},
     printer::{ColorWhen, OutputFormat, Printable},
 };

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,13 +16,14 @@ use subcommands::TuiSubCommand;
 
 use interactive::InteractiveEnv;
 use subcommands::{
-    start_index_thread, AccountSubCommand, CliSubCommand, IndexThreadState, MockTxSubCommand,
-    MoleculeSubCommand, RpcSubCommand, TxSubCommand, UtilSubCommand, WalletSubCommand,
+    start_index_thread, AccountSubCommand, CliSubCommand, MockTxSubCommand, MoleculeSubCommand,
+    RpcSubCommand, TxSubCommand, UtilSubCommand, WalletSubCommand,
 };
 use utils::other::sync_to_tip;
 use utils::{
     arg_parser::{ArgParser, UrlParser},
     config::GlobalConfig,
+    index::IndexThreadState,
     other::{check_alerts, get_key_store, get_network_type, index_dirname},
     printer::{ColorWhen, OutputFormat},
 };
@@ -97,7 +98,7 @@ fn main() -> Result<(), io::Error> {
     // to the tip before executing the command.
     let wait_for_sync = matches.is_present("wait-for-sync");
     if wait_for_sync {
-        if let Err(err) = sync_to_tip(&mut rpc_client, &index_dir) {
+        if let Err(err) = sync_to_tip(&index_controller) {
             eprintln!("Synchronize error: {}", err);
             process::exit(1);
         }

--- a/src/subcommands/mod.rs
+++ b/src/subcommands/mod.rs
@@ -17,10 +17,7 @@ pub use molecule::MoleculeSubCommand;
 pub use rpc::RpcSubCommand;
 pub use tx::TxSubCommand;
 pub use util::UtilSubCommand;
-pub use wallet::{
-    start_index_thread, IndexController, IndexRequest, IndexResponse, IndexThreadState,
-    WalletSubCommand,
-};
+pub use wallet::{start_index_thread, WalletSubCommand};
 
 use clap::ArgMatches;
 

--- a/src/subcommands/tui/mod.rs
+++ b/src/subcommands/tui/mod.rs
@@ -27,8 +27,10 @@ use ckb_types::{
     H256,
 };
 
-use super::wallet::{IndexController, IndexRequest};
-use crate::utils::other::get_network_type;
+use crate::utils::{
+    index::{IndexController, IndexRequest},
+    other::get_network_type,
+};
 use state::{start_rpc_thread, State, SummaryInfo};
 use util::{human_capacity, ts_now, App, Event, Events, TabsState};
 use widgets::List;

--- a/src/subcommands/wallet/index.rs
+++ b/src/subcommands/wallet/index.rs
@@ -1,4 +1,3 @@
-use std::fmt;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -9,193 +8,33 @@ use ckb_index::{with_index_db, IndexDatabase};
 use ckb_sdk::GenesisInfo;
 use ckb_sdk::HttpRpcClient;
 use ckb_types::{
-    core::{service::Request, BlockView, HeaderView},
+    core::{service::Request, BlockView},
     prelude::*,
     H256,
 };
 use ckb_util::RwLock;
-use crossbeam_channel::{Receiver, Sender};
-use serde_derive::{Deserialize, Serialize};
+use crossbeam_channel::Receiver;
 
+use crate::utils::index::{IndexController, IndexRequest, IndexResponse, IndexThreadState};
 use crate::utils::other::get_network_type;
-
-pub enum IndexRequest {
-    UpdateUrl(String),
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub enum IndexResponse {
-    Ok,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct CapacityResult {
-    pub lock_hash: H256,
-    pub address: Option<String>,
-    pub capacity: u64,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct SimpleBlockInfo {
-    epoch: (u64, u64, u64),
-    number: u64,
-    hash: H256,
-}
-
-impl From<HeaderView> for SimpleBlockInfo {
-    fn from(header: HeaderView) -> SimpleBlockInfo {
-        let epoch = header.epoch();
-        SimpleBlockInfo {
-            number: header.number(),
-            epoch: (epoch.number(), epoch.index(), epoch.length()),
-            hash: header.hash().unpack(),
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub enum IndexThreadState {
-    // wait first request to start
-    WaitToStart,
-    // Started init db
-    StartInit,
-    // Process after init db
-    Processing(Option<SimpleBlockInfo>, u64),
-    Error(String),
-    // Thread exit
-    Stopped,
-}
-
-impl IndexThreadState {
-    fn start_init(&mut self) {
-        *self = IndexThreadState::StartInit;
-    }
-    fn processing(&mut self, header: Option<HeaderView>, tip_number: u64) {
-        let block_info = header.map(Into::into);
-        *self = IndexThreadState::Processing(block_info, tip_number);
-    }
-    fn error(&mut self, err: String) {
-        *self = IndexThreadState::Error(err);
-    }
-    fn stop(&mut self) {
-        *self = IndexThreadState::Stopped;
-    }
-    pub fn is_started(&self) -> bool {
-        match self {
-            IndexThreadState::WaitToStart => false,
-            _ => true,
-        }
-    }
-    pub fn is_stopped(&self) -> bool {
-        match self {
-            IndexThreadState::Stopped => true,
-            _ => false,
-        }
-    }
-    pub fn is_error(&self) -> bool {
-        match self {
-            IndexThreadState::Error(_) => true,
-            _ => false,
-        }
-    }
-    #[cfg_attr(windows, allow(dead_code))]
-    pub fn is_processing(&self) -> bool {
-        match self {
-            IndexThreadState::Processing(Some(_), _) => true,
-            _ => false,
-        }
-    }
-}
-
-impl fmt::Display for IndexThreadState {
-    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
-        let output = match self {
-            IndexThreadState::WaitToStart => "Waiting for first query".to_owned(),
-            IndexThreadState::StartInit => "Initializing".to_owned(),
-            IndexThreadState::Error(err) => format!("Error: {}", err),
-            IndexThreadState::Processing(Some(SimpleBlockInfo { number, .. }), tip_number) => {
-                let status = if tip_number == number {
-                    "synced".to_owned()
-                } else {
-                    format!("tip#{}", tip_number)
-                };
-                format!("Processed block#{} ({})", number, status)
-            }
-            IndexThreadState::Processing(None, tip_number) => {
-                format!("Initializing (tip#{})", tip_number)
-            }
-            IndexThreadState::Stopped => "Stopped".to_owned(),
-        };
-        write!(f, "{}", output)
-    }
-}
-
-impl Default for IndexThreadState {
-    fn default() -> IndexThreadState {
-        IndexThreadState::WaitToStart
-    }
-}
-
-pub struct IndexController {
-    state: Arc<RwLock<IndexThreadState>>,
-    sender: Sender<Request<IndexRequest, IndexResponse>>,
-    shutdown: Arc<AtomicBool>,
-}
-
-impl Clone for IndexController {
-    fn clone(&self) -> IndexController {
-        IndexController {
-            state: Arc::clone(&self.state),
-            shutdown: Arc::clone(&self.shutdown),
-            sender: self.sender.clone(),
-        }
-    }
-}
-
-impl IndexController {
-    pub fn state(&self) -> &Arc<RwLock<IndexThreadState>> {
-        &self.state
-    }
-    pub fn sender(&self) -> &Sender<Request<IndexRequest, IndexResponse>> {
-        &self.sender
-    }
-    pub fn shutdown(&self) {
-        let start_time = Instant::now();
-        self.shutdown.store(true, Ordering::Relaxed);
-        while self.state().read().is_started() && !self.state().read().is_stopped() {
-            if self.state().read().is_error() {
-                return;
-            }
-            if start_time.elapsed() < Duration::from_secs(10) {
-                thread::sleep(Duration::from_millis(50));
-            } else {
-                eprintln!(
-                    "Stop index thread timeout(state: {}), give up",
-                    self.state().read().to_string()
-                );
-                return;
-            }
-        }
-    }
-}
 
 pub fn start_index_thread(
     url: &str,
     index_dir: PathBuf,
     state: Arc<RwLock<IndexThreadState>>,
 ) -> IndexController {
-    let mut rpc_url = url.to_owned();
     let (sender, receiver) = crossbeam_channel::bounded::<Request<IndexRequest, IndexResponse>>(1);
     let shutdown = Arc::new(AtomicBool::new(false));
     let state_clone = Arc::clone(&state);
     let shutdown_clone = Arc::clone(&shutdown);
+    let mut rpc_client = HttpRpcClient::new(url.to_owned());
 
     thread::Builder::new()
         .name("index".to_string())
         .spawn(move || {
             loop {
                 // Wait first request
-                match try_recv(&receiver, &mut rpc_url) {
+                match try_recv(&receiver, &mut rpc_client) {
                     Some(true) => {
                         state.write().stop();
                         log::info!("Index database thread stopped");
@@ -206,11 +45,9 @@ pub fn start_index_thread(
                 }
             }
 
-            let mut rpc_client = HttpRpcClient::new(rpc_url.clone());
             loop {
                 match process(
                     &receiver,
-                    &mut rpc_url,
                     &mut rpc_client,
                     &index_dir,
                     &state,
@@ -235,30 +72,21 @@ pub fn start_index_thread(
         })
         .expect("Spawn index thread failed");
 
-    IndexController {
-        state: state_clone,
-        sender,
-        shutdown,
-    }
+    IndexController::new(state_clone, sender, shutdown)
 }
 
 fn process(
     receiver: &Receiver<Request<IndexRequest, IndexResponse>>,
-    rpc_url: &mut String,
     rpc_client: &mut HttpRpcClient,
     index_dir: &PathBuf,
     state: &Arc<RwLock<IndexThreadState>>,
     shutdown: &Arc<AtomicBool>,
 ) -> Result<bool, String> {
-    let old_rpc_url = rpc_url.clone();
-    if let Some(exit) = try_recv(&receiver, rpc_url) {
+    if let Some(exit) = try_recv(&receiver, rpc_client) {
         return Ok(exit);
     }
 
     state.write().start_init();
-    if &old_rpc_url != rpc_url {
-        *rpc_client = HttpRpcClient::new(rpc_url.clone());
-    }
     let genesis_block: BlockView = rpc_client
         .get_block_by_number(0)?
         .expect("Can not get genesis block?")
@@ -291,7 +119,7 @@ fn process(
                     if shutdown.load(Ordering::Relaxed) {
                         return Ok(Some(true));
                     }
-                    if let Some(exit) = try_recv(&receiver, rpc_url) {
+                    if let Some(exit) = try_recv(&receiver, rpc_client) {
                         return Ok(Some(exit));
                     }
                     if let Some(next_block) =
@@ -322,7 +150,7 @@ fn process(
         if shutdown.load(Ordering::Relaxed) {
             return Ok(true);
         }
-        if let Some(exit) = try_recv(&receiver, rpc_url) {
+        if let Some(exit) = try_recv(&receiver, rpc_client) {
             return Ok(exit);
         }
         thread::sleep(Duration::from_millis(100));
@@ -331,10 +159,10 @@ fn process(
 
 fn try_recv(
     receiver: &Receiver<Request<IndexRequest, IndexResponse>>,
-    rpc_url: &mut String,
+    rpc_client: &mut HttpRpcClient,
 ) -> Option<bool> {
     match receiver.try_recv() {
-        Ok(request) => Some(process_request(request, rpc_url)),
+        Ok(request) => Some(process_request(request, rpc_client)),
         Err(err) => {
             if err.is_disconnected() {
                 log::info!("Sender dropped, exit index thread");
@@ -346,15 +174,21 @@ fn try_recv(
     }
 }
 
-fn process_request(request: Request<IndexRequest, IndexResponse>, rpc_url: &mut String) -> bool {
+fn process_request(
+    request: Request<IndexRequest, IndexResponse>,
+    rpc_client: &mut HttpRpcClient,
+) -> bool {
     let Request {
         responder,
         arguments,
     } = request;
     match arguments {
         IndexRequest::UpdateUrl(url) => {
-            *rpc_url = url;
+            if url != rpc_client.url() {
+                *rpc_client = HttpRpcClient::new(url);
+            }
             responder.send(IndexResponse::Ok).is_err()
         }
+        IndexRequest::Kick => false,
     }
 }

--- a/src/subcommands/wallet/mod.rs
+++ b/src/subcommands/wallet/mod.rs
@@ -20,6 +20,7 @@ use crate::utils::{
         AddressParser, ArgParser, CapacityParser, FixedHashParser, FromStrParser,
         PrivkeyPathParser, PrivkeyWrapper,
     },
+    index::IndexController,
     other::{
         check_capacity, get_address, get_live_cell_with_cache, get_network_type,
         get_privkey_signer, get_to_data, read_password, serialize_signature,
@@ -37,10 +38,7 @@ use ckb_sdk::{
     Address, AddressPayload, GenesisInfo, HttpRpcClient, HumanCapacity, MultisigConfig, SignerFn,
     Since, SinceType, TxHelper, SECP256K1,
 };
-pub use index::{
-    start_index_thread, CapacityResult, IndexController, IndexRequest, IndexResponse,
-    IndexThreadState, SimpleBlockInfo,
-};
+pub use index::start_index_thread;
 
 // Max derived change address to search
 const DERIVE_CHANGE_ADDRESS_MAX_LEN: u32 = 10000;

--- a/src/utils/config.rs
+++ b/src/utils/config.rs
@@ -9,8 +9,10 @@ use ckb_sdk::NetworkType;
 use ckb_util::RwLock;
 use regex::{Captures, Regex};
 
-use crate::subcommands::wallet::IndexThreadState;
-use crate::utils::printer::{OutputFormat, Printable};
+use crate::utils::{
+    index::IndexThreadState,
+    printer::{OutputFormat, Printable},
+};
 
 const DEFAULT_JSONRPC_URL: &str = "http://127.0.0.1:8114";
 

--- a/src/utils/index.rs
+++ b/src/utils/index.rs
@@ -1,0 +1,200 @@
+use std::fmt;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
+use std::thread;
+use std::time::{Duration, Instant};
+
+use ckb_types::{
+    core::{service::Request, HeaderView},
+    prelude::*,
+    H256,
+};
+use ckb_util::RwLock;
+use crossbeam_channel::Sender;
+use serde_derive::{Deserialize, Serialize};
+
+pub enum IndexRequest {
+    Kick,
+    UpdateUrl(String),
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub enum IndexResponse {
+    Ok,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CapacityResult {
+    pub lock_hash: H256,
+    pub address: Option<String>,
+    pub capacity: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SimpleBlockInfo {
+    epoch: (u64, u64, u64),
+    number: u64,
+    hash: H256,
+}
+
+impl From<HeaderView> for SimpleBlockInfo {
+    fn from(header: HeaderView) -> SimpleBlockInfo {
+        let epoch = header.epoch();
+        SimpleBlockInfo {
+            number: header.number(),
+            epoch: (epoch.number(), epoch.index(), epoch.length()),
+            hash: header.hash().unpack(),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum IndexThreadState {
+    // wait first request to start
+    WaitToStart,
+    // Started init db
+    StartInit,
+    // Process after init db
+    Processing(Option<SimpleBlockInfo>, u64),
+    Error(String),
+    // Thread exit
+    Stopped,
+}
+
+impl IndexThreadState {
+    pub fn start_init(&mut self) {
+        *self = IndexThreadState::StartInit;
+    }
+    pub fn processing(&mut self, header: Option<HeaderView>, tip_number: u64) {
+        let block_info = header.map(Into::into);
+        *self = IndexThreadState::Processing(block_info, tip_number);
+    }
+    pub fn error(&mut self, err: String) {
+        *self = IndexThreadState::Error(err);
+    }
+    pub fn stop(&mut self) {
+        *self = IndexThreadState::Stopped;
+    }
+    pub fn get_error(&self) -> Option<String> {
+        match self {
+            IndexThreadState::Error(err) => Some(err.clone()),
+            _ => None,
+        }
+    }
+    pub fn is_started(&self) -> bool {
+        match self {
+            IndexThreadState::WaitToStart => false,
+            _ => true,
+        }
+    }
+    pub fn is_stopped(&self) -> bool {
+        match self {
+            IndexThreadState::Stopped => true,
+            _ => false,
+        }
+    }
+    pub fn is_synced(&self) -> bool {
+        match self {
+            IndexThreadState::Processing(Some(SimpleBlockInfo { number, .. }), tip_number) => {
+                number == tip_number
+            }
+            _ => false,
+        }
+    }
+    pub fn is_error(&self) -> bool {
+        match self {
+            IndexThreadState::Error(_) => true,
+            _ => false,
+        }
+    }
+    #[cfg_attr(windows, allow(dead_code))]
+    pub fn is_processing(&self) -> bool {
+        match self {
+            IndexThreadState::Processing(Some(_), _) => true,
+            _ => false,
+        }
+    }
+}
+
+impl fmt::Display for IndexThreadState {
+    fn fmt(&self, f: &mut fmt::Formatter) -> Result<(), fmt::Error> {
+        let output = match self {
+            IndexThreadState::WaitToStart => "Waiting for first query".to_owned(),
+            IndexThreadState::StartInit => "Initializing".to_owned(),
+            IndexThreadState::Error(err) => format!("Error: {}", err),
+            IndexThreadState::Processing(Some(SimpleBlockInfo { number, .. }), tip_number) => {
+                let status = if tip_number == number {
+                    "synced".to_owned()
+                } else {
+                    format!("tip#{}", tip_number)
+                };
+                format!("Processed block#{} ({})", number, status)
+            }
+            IndexThreadState::Processing(None, tip_number) => {
+                format!("Initializing (tip#{})", tip_number)
+            }
+            IndexThreadState::Stopped => "Stopped".to_owned(),
+        };
+        write!(f, "{}", output)
+    }
+}
+
+impl Default for IndexThreadState {
+    fn default() -> IndexThreadState {
+        IndexThreadState::WaitToStart
+    }
+}
+
+pub struct IndexController {
+    state: Arc<RwLock<IndexThreadState>>,
+    sender: Sender<Request<IndexRequest, IndexResponse>>,
+    shutdown: Arc<AtomicBool>,
+}
+
+impl Clone for IndexController {
+    fn clone(&self) -> IndexController {
+        IndexController {
+            state: Arc::clone(&self.state),
+            shutdown: Arc::clone(&self.shutdown),
+            sender: self.sender.clone(),
+        }
+    }
+}
+
+impl IndexController {
+    pub fn new(
+        state: Arc<RwLock<IndexThreadState>>,
+        sender: Sender<Request<IndexRequest, IndexResponse>>,
+        shutdown: Arc<AtomicBool>,
+    ) -> IndexController {
+        IndexController {
+            state,
+            sender,
+            shutdown,
+        }
+    }
+    pub fn state(&self) -> &Arc<RwLock<IndexThreadState>> {
+        &self.state
+    }
+    pub fn sender(&self) -> &Sender<Request<IndexRequest, IndexResponse>> {
+        &self.sender
+    }
+    pub fn shutdown(&self) {
+        let start_time = Instant::now();
+        self.shutdown.store(true, Ordering::Relaxed);
+        while self.state().read().is_started() && !self.state().read().is_stopped() {
+            if self.state().read().is_error() {
+                return;
+            }
+            if start_time.elapsed() < Duration::from_secs(10) {
+                thread::sleep(Duration::from_millis(50));
+            } else {
+                eprintln!(
+                    "Stop index thread timeout(state: {}), give up",
+                    self.state().read().to_string()
+                );
+                return;
+            }
+        }
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,6 +2,7 @@ pub mod arg;
 pub mod arg_parser;
 pub mod completer;
 pub mod config;
+pub mod index;
 pub mod json_color;
 pub mod other;
 pub mod printer;


### PR DESCRIPTION
`reader.iter_from` spend too much time to scan the database (scan every 1 block), now only scan the database when need (when commit batch of blocks, which about 200 blocks). It will increase sync speed about 14 times.

Also `Fix --wait-for-sync`

```
ckb-cli rpc get_tip_block_number
108601

# Old version
time ./target/release/ckb-cli --wait-for-sync wallet top-capacity
./target/release/ckb-cli --wait-for-sync wallet top-capacity  1792.77s user 98.92s system 97% cpu 32:27.96 total

# New version
time ckb-cli --wait-for-sync wallet top-capacity
ckb-cli --wait-for-sync wallet top-capacity  129.03s user 18.65s system 73% cpu 3:21.45 total
```