### PR TITLE
feat: Sign any binary and verify by the signature

### DIFF
--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -336,12 +336,8 @@ impl InteractiveEnv {
                     Ok(())
                 }
                 ("util", Some(sub_matches)) => {
-                    let output = UtilSubCommand::new(&mut self.rpc_client).process(
-                        &sub_matches,
-                        format,
-                        color,
-                        debug,
-                    )?;
+                    let output = UtilSubCommand::new(&mut self.rpc_client, &mut self.key_store)
+                        .process(&sub_matches, format, color, debug)?;
                     println!("{}", output);
                     Ok(())
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -142,9 +142,14 @@ fn main() -> Result<(), io::Error> {
                 debug,
             )
         }),
-        ("util", Some(sub_matches)) => {
-            UtilSubCommand::new(&mut rpc_client).process(&sub_matches, output_format, color, debug)
-        }
+        ("util", Some(sub_matches)) => get_key_store(&ckb_cli_dir).and_then(|mut key_store| {
+            UtilSubCommand::new(&mut rpc_client, &mut key_store).process(
+                &sub_matches,
+                output_format,
+                color,
+                debug,
+            )
+        }),
         ("molecule", Some(sub_matches)) => {
             MoleculeSubCommand::new().process(&sub_matches, output_format, color, debug)
         }

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -7,7 +7,7 @@ pub mod util;
 use crate::app::App;
 use crate::setup::Setup;
 use crate::spec::{
-    DaoPrepareMultiple, DaoPrepareOne, DaoWithdrawMultiple, RpcGetTipBlockNumber, Spec,
+    DaoPrepareMultiple, DaoPrepareOne, DaoWithdrawMultiple, RpcGetTipBlockNumber, Spec, Util,
     WalletTimelockedAddress, WalletTransfer,
 };
 use crate::util::{find_available_port, run_cmd, temp_dir};
@@ -62,5 +62,6 @@ fn all_specs() -> Vec<Box<dyn Spec>> {
         Box::new(DaoPrepareOne),
         Box::new(DaoPrepareMultiple),
         Box::new(DaoWithdrawMultiple),
+        Box::new(Util),
     ]
 }

--- a/test/src/spec/mod.rs
+++ b/test/src/spec/mod.rs
@@ -1,9 +1,11 @@
 mod dao;
 mod rpc;
+mod util;
 mod wallet;
 
 pub use dao::*;
 pub use rpc::*;
+pub use util::*;
 pub use wallet::*;
 
 use crate::setup::Setup;

--- a/test/src/spec/util.rs
+++ b/test/src/spec/util.rs
@@ -1,0 +1,106 @@
+use crate::setup::Setup;
+use crate::spec::Spec;
+use std::fs;
+use tempfile::tempdir;
+
+pub struct Util;
+
+pub const ACCOUNT_PRIVKEY: &str =
+    "0x3b5ca3bd98b6a57f36b3f6fa138c4004e92a37dee39069606ee65c742e5f9170";
+pub const ACCOUNT_ADDRESS: &str = "ckt1qyqp76jus2sst4qy57nnphuqgsmlmzkv2l7s8ksggy";
+
+impl Spec for Util {
+    fn run(&self, setup: &mut Setup) {
+        let tempdir = tempdir().expect("create tempdir failed");
+        let path = tempdir.path().to_str().unwrap().to_owned();
+        let account_privkey = format!("{}/account", path);
+        fs::write(&account_privkey, ACCOUNT_PRIVKEY).unwrap();
+
+        let output = setup.cli(&format!(
+            "util sign-data --binary-hex 0xdeadbeef --privkey-path {}",
+            account_privkey
+        ));
+        let value: serde_yaml::Value = serde_yaml::from_str(&output).unwrap();
+        let message = value["message"].as_str().unwrap();
+        let signature1 = value["signature"].as_str().unwrap();
+        assert_eq!(
+            message,
+            "0x761b06536d4d9580de9b63a3d5c5a5da0c6826c39775a7ce5039ac7e0f7f5dbc"
+        );
+        assert_eq!(signature1, "0x3f5aad8439367a7840deffbf3ee7657b9b225c553f7d5a4f766d99ac78128a6f7de732923d4dcf4551ff97421f104aa33d83d14362ab276502580cdd66fd56ee");
+
+        let output = setup.cli(&format!(
+            "util sign-message --message {} --privkey-path {}",
+            message, account_privkey
+        ));
+        let value: serde_yaml::Value = serde_yaml::from_str(&output).unwrap();
+        let signature2 = value["signature"].as_str().unwrap();
+        assert_eq!(signature1, signature2);
+
+        let output = setup.cli(&format!(
+            "util verify-signature --message {} --signature {} --privkey-path {}",
+            message, signature1, account_privkey,
+        ));
+        let value: serde_yaml::Value = serde_yaml::from_str(&output).unwrap();
+        let pubkey = value["pubkey"].as_str().unwrap();
+        let recoverable = value["recoverable"].as_bool().unwrap();
+        let verify_ok = value["verify-ok"].as_bool().unwrap();
+        assert_eq!(
+            pubkey,
+            "0x0237813f0b34ddccaef22947e934fa0af384d1551ab1ad268860a8fe65a1f8f69d"
+        );
+        assert_eq!(recoverable, false);
+        assert_eq!(verify_ok, true);
+
+        let output = setup.cli(&format!(
+            "util verify-signature --message {} --signature {} --privkey-path {}",
+            message,
+            "0xaaaaaa8439367a7840deffbf3ee7657b9b225c553f7d5a4f766d99ac78128a6f7de732923d4dcf4551ff97421f104aa33d83d14362ab276502580cdd66fd56ee",
+            account_privkey,
+        ));
+        let value: serde_yaml::Value = serde_yaml::from_str(&output).unwrap();
+        let verify_ok = value["verify-ok"].as_bool().unwrap();
+        assert_eq!(verify_ok, false);
+
+        // Recoverable signature
+        let output = setup.cli(&format!(
+            "util sign-data --binary-hex 0xdeadbeef --privkey-path {} --recoverable",
+            account_privkey
+        ));
+        let value: serde_yaml::Value = serde_yaml::from_str(&output).unwrap();
+        let message = value["message"].as_str().unwrap();
+        let signature = value["signature"].as_str().unwrap();
+        assert_eq!(
+            message,
+            "0x761b06536d4d9580de9b63a3d5c5a5da0c6826c39775a7ce5039ac7e0f7f5dbc"
+        );
+        assert_eq!(signature, "0x3f5aad8439367a7840deffbf3ee7657b9b225c553f7d5a4f766d99ac78128a6f7de732923d4dcf4551ff97421f104aa33d83d14362ab276502580cdd66fd56ee00");
+
+        let output = setup.cli(&format!(
+            "util verify-signature --message {} --signature {} --privkey-path {}",
+            message, signature, account_privkey,
+        ));
+        let value: serde_yaml::Value = serde_yaml::from_str(&output).unwrap();
+        let pubkey = value["pubkey"].as_str().unwrap();
+        let recoverable = value["recoverable"].as_bool().unwrap();
+        let verify_ok = value["verify-ok"].as_bool().unwrap();
+        assert_eq!(
+            pubkey,
+            "0x0237813f0b34ddccaef22947e934fa0af384d1551ab1ad268860a8fe65a1f8f69d"
+        );
+        assert_eq!(recoverable, true);
+        assert_eq!(verify_ok, true);
+
+        let output = setup.cli(&format!(
+            "util verify-signature --message {} --signature {} --privkey-path {}",
+            message,
+            "0xaaaaaa8439367a7840deffbf3ee7657b9b225c553f7d5a4f766d99ac78128a6f7de732923d4dcf4551ff97421f104aa33d83d14362ab276502580cdd66fd56ee00",
+            account_privkey,
+        ));
+        let value: serde_yaml::Value = serde_yaml::from_str(&output).unwrap();
+        let recoverable = value["recoverable"].as_bool().unwrap();
+        let verify_ok = value["verify-ok"].as_bool().unwrap();
+        assert_eq!(recoverable, true);
+        assert_eq!(verify_ok, false);
+    }
+}


### PR DESCRIPTION
```
# Sign data
CKB> util sign-data --binary-hex 0xdeadbeef --privkey-path ../privkey
message: 0x761b06536d4d9580de9b63a3d5c5a5da0c6826c39775a7ce5039ac7e0f7f5dbc
recoverable: false
signature: 0x3f5aad8439367a7840deffbf3ee7657b9b225c553f7d5a4f766d99ac78128a6f7de732923d4dcf4551ff97421f104aa33d83d14362ab276502580cdd66fd56ee

# Sign with recoverable signature
CKB> util sign-data --binary-hex 0xdeadbeef --privkey-path ../privkey --recoverable
message: 0x761b06536d4d9580de9b63a3d5c5a5da0c6826c39775a7ce5039ac7e0f7f5dbc
recoverable: true
signature: 0x3f5aad8439367a7840deffbf3ee7657b9b225c553f7d5a4f766d99ac78128a6f7de732923d4dcf4551ff97421f104aa33d83d14362ab276502580cdd66fd56ee00

# Sign message
CKB> util sign-message --message 0x761b06536d4d9580de9b63a3d5c5a5da0c6826c39775a7ce5039ac7e0f7f5dbc --privkey-path ../privkey
recoverable: false
signature: 0x3f5aad8439367a7840deffbf3ee7657b9b225c553f7d5a4f766d99ac78128a6f7de732923d4dcf4551ff97421f104aa33d83d14362ab276502580cdd66fd56ee

# Verify signature with corresponding message
CKB> util verify-signature --message 0x761b06536d4d9580de9b63a3d5c5a5da0c6826c39775a7ce5039ac7e0f7f5dbc --signature 0x3f5aad8439367a7840deffbf3ee7657b9b225c553f7d5a4f766d99ac78128a6f7de732923d4dcf4551ff97421f104aa33d83d14362ab276502580cdd66fd56ee --privkey-path ../privkey
pubkey: 0x0237813f0b34ddccaef22947e934fa0af384d1551ab1ad268860a8fe65a1f8f69d
recoverable: false
verify-ok: true
```