### PR TITLE
refactor: `DerivationPath` is fine w/o `Option`

### DIFF
--- a/ckb-sdk/src/wallet/bip32.rs
+++ b/ckb-sdk/src/wallet/bip32.rs
@@ -16,6 +16,7 @@
 //! Implementation of BIP32 hierarchical deterministic wallets, as defined
 //! at https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki
 
+use std::borrow::Borrow;
 use std::default::Default;
 use std::io::Write;
 use std::str::FromStr;
@@ -344,6 +345,12 @@ impl<'a> ::std::iter::IntoIterator for &'a DerivationPath {
     }
 }
 
+impl Borrow<[ChildNumber]> for DerivationPath {
+    fn borrow(&self) -> &[ChildNumber] {
+        &self.0
+    }
+}
+
 impl AsRef<[ChildNumber]> for DerivationPath {
     fn as_ref(&self) -> &[ChildNumber] {
         &self.0
@@ -395,6 +402,10 @@ impl<'a> Iterator for DerivationPathIterator<'a> {
 }
 
 impl DerivationPath {
+    /// Create the empty [DerivationPath] which refers to the original key.
+    pub fn empty() -> Self {
+        DerivationPath(Vec::new())
+    }
     /// Create a new [DerivationPath] that is a child of this one.
     pub fn child(&self, cn: ChildNumber) -> DerivationPath {
         let mut path = self.0.clone();
@@ -526,7 +537,7 @@ impl ExtendedPrivKey {
     /// Attempts to derive an extended private key from a path.
     ///
     /// The `path` argument can be both of type `DerivationPath` or `Vec<ChildNumber>`.
-    pub fn derive_priv<C: secp256k1::Signing, P: AsRef<[ChildNumber]>>(
+    pub fn derive_priv<C: secp256k1::Signing, P: ?Sized + AsRef<[ChildNumber]>>(
         &self,
         secp: &Secp256k1<C>,
         path: &P,
@@ -603,7 +614,7 @@ impl ExtendedPubKey {
     /// Attempts to derive an extended public key from a path.
     ///
     /// The `path` argument can be both of type `DerivationPath` or `Vec<ChildNumber>`.
-    pub fn derive_pub<C: secp256k1::Verification, P: AsRef<[ChildNumber]>>(
+    pub fn derive_pub<C: secp256k1::Verification, P: ?Sized + AsRef<[ChildNumber]>>(
         &self,
         secp: &Secp256k1<C>,
         path: &P,

--- a/src/subcommands/account.rs
+++ b/src/subcommands/account.rs
@@ -345,13 +345,14 @@ impl<'a> CliSubCommand for AccountSubCommand<'a> {
             ("extended-address", Some(m)) => {
                 let lock_arg: H160 =
                     FixedHashParser::<H160>::default().from_matches(m, "lock-arg")?;
-                let path: Option<DerivationPath> =
-                    FromStrParser::<DerivationPath>::new().from_matches_opt(m, "path", false)?;
+                let path: DerivationPath = FromStrParser::<DerivationPath>::new()
+                    .from_matches_opt(m, "path", false)?
+                    .unwrap_or_else(DerivationPath::empty);
 
                 let password = read_password(false, None)?;
                 let extended_pubkey = self
                     .key_store
-                    .extended_pubkey_with_password(&lock_arg, path.as_ref(), password.as_bytes())
+                    .extended_pubkey_with_password(&lock_arg, &path, password.as_bytes())
                     .map_err(|err| err.to_string())?;
                 let address_payload = AddressPayload::from_pubkey(&extended_pubkey.public_key);
                 let resp = serde_json::json!({

--- a/src/subcommands/dao/mod.rs
+++ b/src/subcommands/dao/mod.rs
@@ -327,7 +327,7 @@ fn get_keystore_signer(key_store: KeyStore, account: H160, password: String) -> 
                 Ok(Some([0u8; 65]))
             } else {
                 key_store
-                    .sign_recoverable_with_password(&account, None, message, password.as_bytes())
+                    .sign_recoverable_with_password(&account, &[], message, password.as_bytes())
                     .map(|signature| Some(serialize_signature(&signature)))
                     .map_err(|err| err.to_string())
             }

--- a/src/subcommands/tx.rs
+++ b/src/subcommands/tx.rs
@@ -602,7 +602,7 @@ fn get_keystore_signer(key_store: KeyStore, account: H160, password: String) -> 
                 Ok(Some([0u8; 65]))
             } else {
                 key_store
-                    .sign_recoverable_with_password(&account, None, message, password.as_bytes())
+                    .sign_recoverable_with_password(&account, &[], message, password.as_bytes())
                     .map(|signature| Some(serialize_signature(&signature)))
                     .map_err(|err| err.to_string())
             }

--- a/src/subcommands/util.rs
+++ b/src/subcommands/util.rs
@@ -389,7 +389,7 @@ message = "0x"
                 } else if let Some(account) = from_account_opt {
                     let password = read_password(false, None)?;
                     self.key_store
-                        .extended_pubkey_with_password(&account, None, password.as_bytes())
+                        .extended_pubkey_with_password(&account, &[], password.as_bytes())
                         .map_err(|err| err.to_string())?
                         .public_key
                 } else {
@@ -564,14 +564,14 @@ fn sign_message(
         (None, Some((key_store, account)), false) => {
             let password = read_password(false, None)?;
             key_store
-                .sign_with_password(account, None, message, password.as_bytes())
+                .sign_with_password(account, &[], message, password.as_bytes())
                 .map(|sig| sig.serialize_compact().to_vec())
                 .map_err(|err| err.to_string())
         }
         (None, Some((key_store, account)), true) => {
             let password = read_password(false, None)?;
             key_store
-                .sign_recoverable_with_password(account, None, message, password.as_bytes())
+                .sign_recoverable_with_password(account, &[], message, password.as_bytes())
                 .map(|sig| serialize_signature(&sig).to_vec())
                 .map_err(|err| err.to_string())
         }

--- a/src/subcommands/wallet/mod.rs
+++ b/src/subcommands/wallet/mod.rs
@@ -635,20 +635,13 @@ fn get_keystore_signer(
     password: String,
 ) -> SignerFn {
     Box::new(move |lock_args: &HashSet<H160>, message: &H256| {
-        let path = if lock_args.contains(&account) {
-            None
+        let path: &[_] = if lock_args.contains(&account) {
+            &[]
         } else {
-            let mut path_opt = None;
-            for lock_arg in lock_args {
-                if let Some(path) = path_map.get(lock_arg) {
-                    path_opt = Some(path);
-                    break;
-                }
+            match lock_args.iter().find_map(|lock_arg| path_map.get(lock_arg)) {
+                None => return Ok(None),
+                Some(path) => path.as_ref(),
             }
-            if path_opt.is_none() {
-                return Ok(None);
-            }
-            path_opt
         };
         if message == &h256!("0x0") {
             return Ok(Some([0u8; 65]));

--- a/src/utils/other.rs
+++ b/src/utils/other.rs
@@ -80,7 +80,7 @@ pub fn get_singer(
         let prompt = format!("Password for [{:x}]", lock_arg);
         let password = read_password(false, Some(prompt.as_str()))?;
         let signature = key_store
-            .sign_recoverable_with_password(lock_arg, None, tx_hash_hash, password.as_bytes())
+            .sign_recoverable_with_password(lock_arg, &[], tx_hash_hash, password.as_bytes())
             .map_err(|err| err.to_string())?;
         let (recov_id, data) = signature.serialize_compact();
         let mut signature_bytes = [0u8; 65];


### PR DESCRIPTION
The empty derivation path naturally refers to the original key, so an extra `None` value is not needed.

Also, follow bip32 in making a few functions take any `AsRef<[ChildNumber]>`. This make the functions a bit more flexible.