### PR TITLE
refactor: Deduplicate lock-arg arguments

### DIFF
--- a/src/subcommands/account.rs
+++ b/src/subcommands/account.rs
@@ -12,6 +12,7 @@ use clap::{App, Arg, ArgMatches, SubCommand};
 
 use super::CliSubCommand;
 use crate::utils::{
+    arg::lock_arg,
     arg_parser::{
         ArgParser, DurationParser, ExtendedPrivkeyPathParser, FilePathParser, FixedHashParser,
         FromStrParser, PrivkeyPathParser, PrivkeyWrapper,
@@ -30,12 +31,6 @@ impl<'a> AccountSubCommand<'a> {
     }
 
     pub fn subcommand(name: &'static str) -> App<'static, 'static> {
-        let arg_lock_arg = Arg::with_name("lock-arg")
-            .long("lock-arg")
-            .takes_value(true)
-            .validator(|input| FixedHashParser::<H160>::default().validate(input))
-            .required(true)
-            .help("The lock_arg (identifier) of the account");
         let arg_privkey_path = Arg::with_name("privkey-path")
             .long("privkey-path")
             .takes_value(true);
@@ -74,7 +69,7 @@ impl<'a> AccountSubCommand<'a> {
                     ),
                 SubCommand::with_name("unlock")
                     .about("Unlock an account")
-                    .arg(arg_lock_arg.clone())
+                    .arg(lock_arg().required(true))
                     .arg(
                         Arg::with_name("keep")
                             .long("keep")
@@ -85,10 +80,10 @@ impl<'a> AccountSubCommand<'a> {
                     ),
                 SubCommand::with_name("update")
                     .about("Update password of an account")
-                    .arg(arg_lock_arg.clone()),
+                    .arg(lock_arg().required(true)),
                 SubCommand::with_name("export")
                     .about("Export master private key and chain code as hex plain text (USE WITH YOUR OWN RISK)")
-                    .arg(arg_lock_arg.clone())
+                    .arg(lock_arg().required(true))
                     .arg(
                         arg_extended_privkey_path
                             .clone()
@@ -129,10 +124,10 @@ impl<'a> AccountSubCommand<'a> {
                             .validator(|input| FromStrParser::<u32>::default().validate(input))
                             .help("Change addresses length")
                     )
-                    .arg(arg_lock_arg.clone()),
+                    .arg(lock_arg().required(true)),
                 SubCommand::with_name("extended-address")
                     .about("Extended address (see: BIP-44)")
-                    .arg(arg_lock_arg.clone())
+                    .arg(lock_arg().required(true))
                     .arg(
                         Arg::with_name("path")
                             .long("path")

--- a/src/subcommands/mock_tx.rs
+++ b/src/subcommands/mock_tx.rs
@@ -20,6 +20,7 @@ use clap::{App, Arg, ArgMatches, SubCommand};
 
 use super::CliSubCommand;
 use crate::utils::{
+    arg::lock_arg,
     arg_parser::{ArgParser, FilePathParser, FixedHashParser},
     other::{get_genesis_info, get_singer},
     printer::{OutputFormat, Printable},
@@ -56,18 +57,12 @@ impl<'a> MockTxSubCommand<'a> {
             .takes_value(true)
             .validator(|input| FilePathParser::new(false).validate(input))
             .help("Completed mock transaction data file (format: json)");
-        let arg_lock_arg = Arg::with_name("lock-arg")
-            .long("lock-arg")
-            .takes_value(true)
-            .validator(|input| FixedHashParser::<H160>::default().validate(input))
-            .required(true)
-            .help("The lock_arg (identifier) of the account");
         SubCommand::with_name(name)
             .about("Handle mock transactions (verify/send)")
             .subcommands(vec![
                 SubCommand::with_name("template")
                     .about("Print mock transaction template")
-                    .arg(arg_lock_arg.clone().required(false))
+                    .arg(lock_arg().required(true).clone().required(false))
                     .arg(arg_output_file.clone().help("Save to a output file")),
                 SubCommand::with_name("complete")
                     .about("Complete the mock transaction")

--- a/src/subcommands/util.rs
+++ b/src/subcommands/util.rs
@@ -69,11 +69,6 @@ impl<'a> UtilSubCommand<'a> {
             .validator(|input| AddressParser::default().validate(input))
             .required(true)
             .help("Target address (see: https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0021-ckb-address-format/0021-ckb-address-format.md)");
-        let arg_lock_arg = Arg::with_name("lock-arg")
-            .long("lock-arg")
-            .takes_value(true)
-            .validator(|input| FixedHashParser::<H160>::default().validate(input))
-            .help("Lock argument (account identifier, blake2b(pubkey)[0..20])");
 
         let binary_hex_arg = Arg::with_name("binary-hex")
             .long("binary-hex")
@@ -111,7 +106,7 @@ impl<'a> UtilSubCommand<'a> {
                     .arg(arg_privkey.clone().conflicts_with("pubkey"))
                     .arg(arg_pubkey.clone().required(false))
                     .arg(arg_address.clone().required(false))
-                    .arg(arg_lock_arg.clone()),
+                    .arg(arg::lock_arg().clone()),
                 SubCommand::with_name("sign-data")
                     .about("Sign data with secp256k1 signature ")
                     .arg(arg::privkey_path().required_unless(arg::from_account().b.name))


### PR DESCRIPTION
Only tx's is different in being of two possible lengths. It is left as
is but the rest use `arg::lock_arg`.