### PR TITLE
feat: Unify output format and target

### DIFF
--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -299,18 +299,14 @@ impl InteractiveEnv {
                 ("rpc", Some(sub_matches)) => {
                     check_alerts(&mut self.rpc_client);
                     let output = RpcSubCommand::new(&mut self.rpc_client, &mut self.raw_rpc_client)
-                        .process(&sub_matches, format, color, debug)?;
-                    println!("{}", output);
+                        .process(&sub_matches, debug)?;
+                    output.print(format, color);
                     Ok(())
                 }
                 ("account", Some(sub_matches)) => {
-                    let output = AccountSubCommand::new(&mut self.key_store).process(
-                        &sub_matches,
-                        format,
-                        color,
-                        debug,
-                    )?;
-                    println!("{}", output);
+                    let output =
+                        AccountSubCommand::new(&mut self.key_store).process(&sub_matches, debug)?;
+                    output.print(format, color);
                     Ok(())
                 }
                 ("mock-tx", Some(sub_matches)) => {
@@ -320,28 +316,27 @@ impl InteractiveEnv {
                         &mut self.key_store,
                         genesis_info,
                     )
-                    .process(&sub_matches, format, color, debug)?;
-                    println!("{}", output);
+                    .process(&sub_matches, debug)?;
+                    output.print(format, color);
                     Ok(())
                 }
                 ("tx", Some(sub_matches)) => {
                     let genesis_info = self.genesis_info().ok();
                     let output =
                         TxSubCommand::new(&mut self.rpc_client, &mut self.key_store, genesis_info)
-                            .process(&sub_matches, format, color, debug)?;
-                    println!("{}", output);
+                            .process(&sub_matches, debug)?;
+                    output.print(format, color);
                     Ok(())
                 }
                 ("util", Some(sub_matches)) => {
                     let output = UtilSubCommand::new(&mut self.rpc_client, &mut self.key_store)
-                        .process(&sub_matches, format, color, debug)?;
-                    println!("{}", output);
+                        .process(&sub_matches, debug)?;
+                    output.print(format, color);
                     Ok(())
                 }
                 ("molecule", Some(sub_matches)) => {
-                    let output =
-                        MoleculeSubCommand::new().process(&sub_matches, format, color, debug)?;
-                    println!("{}", output);
+                    let output = MoleculeSubCommand::new().process(&sub_matches, debug)?;
+                    output.print(format, color);
                     Ok(())
                 }
                 ("wallet", Some(sub_matches)) => {
@@ -354,8 +349,8 @@ impl InteractiveEnv {
                         self.index_controller.clone(),
                         wait_for_sync,
                     )
-                    .process(&sub_matches, format, color, debug)?;
-                    println!("{}", output);
+                    .process(&sub_matches, debug)?;
+                    output.print(format, color);
                     Ok(())
                 }
                 ("dao", Some(sub_matches)) => {
@@ -368,8 +363,8 @@ impl InteractiveEnv {
                         self.index_controller.clone(),
                         wait_for_sync,
                     )
-                    .process(&sub_matches, format, color, debug)?;
-                    println!("{}", output);
+                    .process(&sub_matches, debug)?;
+                    output.print(format, color);
                     Ok(())
                 }
                 ("exit", _) => {

--- a/src/subcommands/api_server.rs
+++ b/src/subcommands/api_server.rs
@@ -24,13 +24,12 @@ use jsonrpc_server_utils::cors::AccessControlAllowOrigin;
 use jsonrpc_server_utils::hosts::DomainsValidation;
 use serde::{Deserialize, Serialize};
 
-use super::{CliSubCommand, LiveCells, TransferArgs, WalletSubCommand};
+use super::{CliSubCommand, LiveCells, Output, TransferArgs, WalletSubCommand};
 use crate::utils::{
     arg,
     arg_parser::{AddressParser, ArgParser, FromStrParser, PrivkeyPathParser, PrivkeyWrapper},
     index::{IndexController, IndexRequest},
     other::get_network_type,
-    printer::OutputFormat,
 };
 
 pub struct ApiServerSubCommand<'a> {
@@ -78,13 +77,7 @@ impl<'a> ApiServerSubCommand<'a> {
 }
 
 impl<'a> CliSubCommand for ApiServerSubCommand<'a> {
-    fn process(
-        &mut self,
-        matches: &ArgMatches,
-        _format: OutputFormat,
-        _color: bool,
-        _debug: bool,
-    ) -> Result<String, String> {
+    fn process(&mut self, matches: &ArgMatches, _debug: bool) -> Result<Output, String> {
         let listen_addr: SocketAddr =
             FromStrParser::<SocketAddr>::new().from_matches(matches, "listen")?;
         let privkey_path: Option<String> = matches.value_of("privkey-path").map(Into::into);
@@ -139,7 +132,9 @@ impl<'a> CliSubCommand for ApiServerSubCommand<'a> {
         log::info!("Wallet address: {:?}", address_opt);
         log::info!("Listen on {}", listen_addr);
         RpcServer::start(&listen_addr, io_handler).wait();
-        Ok(String::from("Stopped"))
+        Ok(Output::new_error(serde_json::json!({
+            "status": "stopped",
+        })))
     }
 }
 

--- a/src/subcommands/dao/util.rs
+++ b/src/subcommands/dao/util.rs
@@ -1,3 +1,4 @@
+use crate::subcommands::Output;
 use crate::utils::{
     other::check_lack_of_capacity,
     printer::{OutputFormat, Printable},
@@ -94,21 +95,19 @@ pub(crate) fn calculate_dao_maximum_withdraw4(
 pub(crate) fn send_transaction(
     rpc_client: &mut HttpRpcClient,
     transaction: TransactionView,
-    format: OutputFormat,
-    color: bool,
     debug: bool,
-) -> Result<String, String> {
+) -> Result<Output, String> {
     check_lack_of_capacity(&transaction)?;
     let transaction_view: ckb_jsonrpc_types::TransactionView = transaction.clone().into();
     if debug {
-        println!(
+        eprintln!(
             "[Send Transaction]:\n{}",
-            transaction_view.render(format, color)
+            transaction_view.render(OutputFormat::Yaml, false)
         );
     }
 
     let resp = rpc_client.send_transaction(transaction.data())?;
-    Ok(resp.render(format, color))
+    Ok(Output::new_output(resp))
 }
 
 pub(crate) fn minimal_unlock_point(

--- a/src/subcommands/mod.rs
+++ b/src/subcommands/mod.rs
@@ -24,15 +24,57 @@ pub use util::UtilSubCommand;
 pub use wallet::{start_index_thread, LiveCells, TransferArgs, WalletSubCommand};
 
 use clap::ArgMatches;
+use serde::Serialize;
 
-use crate::utils::printer::OutputFormat;
+use crate::utils::printer::{OutputFormat, Printable};
+
+pub struct Output {
+    stdout: Option<serde_json::Value>,
+    stderr: Option<serde_json::Value>,
+    success: bool,
+}
+
+impl Output {
+    pub fn new_success() -> Output {
+        Output {
+            stdout: None,
+            stderr: None,
+            success: true,
+        }
+    }
+
+    pub fn new_output<T: Serialize>(value: T) -> Output {
+        Output {
+            stdout: Some(serde_json::to_value(value).expect("serialize stdout error")),
+            stderr: None,
+            success: false,
+        }
+    }
+
+    pub fn new_error<T: Serialize>(value: T) -> Output {
+        Output {
+            stdout: None,
+            stderr: Some(serde_json::to_value(value).expect("serialize stderr error")),
+            success: false,
+        }
+    }
+
+    pub fn print(&self, format: OutputFormat, color: bool) {
+        if let Some(ref stdout) = self.stdout {
+            println!("{}", stdout.render(format, color));
+        }
+        if let Some(ref stderr) = self.stderr {
+            eprintln!("{}", stderr.render(format, color));
+        }
+        if self.success {
+            let resp = serde_json::json!({
+                "status": "success",
+            });
+            eprintln!("{}", resp.render(OutputFormat::Yaml, color));
+        }
+    }
+}
 
 pub trait CliSubCommand {
-    fn process(
-        &mut self,
-        matches: &ArgMatches,
-        format: OutputFormat,
-        color: bool,
-        debug: bool,
-    ) -> Result<String, String>;
+    fn process(&mut self, matches: &ArgMatches, debug: bool) -> Result<Output, String>;
 }

--- a/src/subcommands/rpc.rs
+++ b/src/subcommands/rpc.rs
@@ -17,11 +17,10 @@ use std::fs;
 use std::path::PathBuf;
 use std::time::Duration;
 
-use super::CliSubCommand;
+use super::{CliSubCommand, Output};
 use crate::utils::arg_parser::{
     ArgParser, DurationParser, FilePathParser, FixedHashParser, FromStrParser,
 };
-use crate::utils::printer::{OutputFormat, Printable};
 
 pub struct RpcSubCommand<'a> {
     rpc_client: &'a mut HttpRpcClient,
@@ -250,13 +249,7 @@ impl<'a> RpcSubCommand<'a> {
 }
 
 impl<'a> CliSubCommand for RpcSubCommand<'a> {
-    fn process(
-        &mut self,
-        matches: &ArgMatches,
-        format: OutputFormat,
-        color: bool,
-        _debug: bool,
-    ) -> Result<String, String> {
+    fn process(&mut self, matches: &ArgMatches, _debug: bool) -> Result<Output, String> {
         let is_raw_data = matches.is_present("raw-data");
         match matches.subcommand() {
             // [Chain]
@@ -270,10 +263,10 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                         .get_block(hash)
                         .map(RawOptionBlockView)
                         .map_err(|err| err.to_string())?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 } else {
                     let resp = self.rpc_client.get_block(hash).map(OptionBlockView)?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 }
             }
             ("get_block_by_number", Some(m)) => {
@@ -286,20 +279,20 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                         .get_block_by_number(BlockNumber::from(number))
                         .map(RawOptionBlockView)
                         .map_err(|err| err.to_string())?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 } else {
                     let resp = self
                         .rpc_client
                         .get_block_by_number(number)
                         .map(OptionBlockView)?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 }
             }
             ("get_block_hash", Some(m)) => {
                 let number: u64 = FromStrParser::<u64>::default().from_matches(m, "number")?;
 
                 let resp = self.rpc_client.get_block_hash(number).map(OptionH256)?;
-                Ok(resp.render(format, color))
+                Ok(Output::new_output(resp))
             }
             ("get_cellbase_output_capacity_details", Some(m)) => {
                 let is_raw_data = is_raw_data || m.is_present("raw-data");
@@ -311,13 +304,13 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                         .get_cellbase_output_capacity_details(hash)
                         .map(RawOptionBlockReward)
                         .map_err(|err| err.to_string())?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 } else {
                     let resp = self
                         .rpc_client
                         .get_cellbase_output_capacity_details(hash)
                         .map(OptionBlockReward)?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 }
             }
             ("get_cells_by_lock_hash", Some(m)) => {
@@ -336,13 +329,13 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                         )
                         .map(RawCellOutputWithOutPoints)
                         .map_err(|err| err.to_string())?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 } else {
                     let resp = self
                         .rpc_client
                         .get_cells_by_lock_hash(lock_hash, from_number, to_number)
                         .map(CellOutputWithOutPoints)?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 }
             }
             ("get_current_epoch", Some(m)) => {
@@ -352,10 +345,10 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                         .raw_rpc_client
                         .get_current_epoch()
                         .map_err(|err| err.to_string())?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 } else {
                     let resp = self.rpc_client.get_current_epoch()?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 }
             }
             ("get_epoch_by_number", Some(m)) => {
@@ -368,13 +361,13 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                         .get_epoch_by_number(EpochNumber::from(number))
                         .map(RawOptionEpochView)
                         .map_err(|err| err.to_string())?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 } else {
                     let resp = self
                         .rpc_client
                         .get_epoch_by_number(number)
                         .map(OptionEpochView)?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 }
             }
             ("get_header", Some(m)) => {
@@ -387,10 +380,10 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                         .get_header(hash)
                         .map(RawOptionHeaderView)
                         .map_err(|err| err.to_string())?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 } else {
                     let resp = self.rpc_client.get_header(hash).map(OptionHeaderView)?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 }
             }
             ("get_header_by_number", Some(m)) => {
@@ -403,13 +396,13 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                         .get_header_by_number(BlockNumber::from(number))
                         .map(RawOptionHeaderView)
                         .map_err(|err| err.to_string())?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 } else {
                     let resp = self
                         .rpc_client
                         .get_header_by_number(number)
                         .map(OptionHeaderView)?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 }
             }
             ("get_live_cell", Some(m)) => {
@@ -428,10 +421,10 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                         .raw_rpc_client
                         .get_live_cell(out_point.into(), with_data)
                         .map_err(|err| err.to_string())?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 } else {
                     let resp = self.rpc_client.get_live_cell(out_point, with_data)?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 }
             }
             ("get_tip_block_number", Some(m)) => {
@@ -441,13 +434,13 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                         .raw_rpc_client
                         .get_tip_block_number()
                         .map_err(|err| err.to_string())?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 } else {
                     let resp = self
                         .rpc_client
                         .get_tip_block_number()
                         .map(|number| serde_json::json!(number))?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 }
             }
             ("get_tip_header", Some(m)) => {
@@ -457,10 +450,10 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                         .raw_rpc_client
                         .get_tip_header()
                         .map_err(|err| err.to_string())?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 } else {
                     let resp = self.rpc_client.get_tip_header()?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 }
             }
             ("get_transaction", Some(m)) => {
@@ -473,20 +466,20 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                         .get_transaction(hash)
                         .map(RawOptionTransactionWithStatus)
                         .map_err(|err| err.to_string())?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 } else {
                     let resp = self
                         .rpc_client
                         .get_transaction(hash)
                         .map(OptionTransactionWithStatus)?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 }
             }
             // [Indexer]
             ("deindex_lock_hash", Some(m)) => {
                 let hash: H256 = FixedHashParser::<H256>::default().from_matches(m, "hash")?;
                 self.rpc_client.deindex_lock_hash(hash)?;
-                Ok(String::from("ok"))
+                Ok(Output::new_success())
             }
             ("get_live_cells_by_lock_hash", Some(m)) => {
                 let is_raw_data = is_raw_data || m.is_present("raw-data");
@@ -506,7 +499,7 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                         )
                         .map(RawLiveCells)
                         .map_err(|err| err.to_string())?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 } else {
                     let resp = self
                         .rpc_client
@@ -517,7 +510,7 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                             Some(reverse_order),
                         )
                         .map(LiveCells)?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 }
             }
             ("get_transactions_by_lock_hash", Some(m)) => {
@@ -538,7 +531,7 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                         )
                         .map(RawCellTransactions)
                         .map_err(|err| err.to_string())?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 } else {
                     let resp = self
                         .rpc_client
@@ -549,7 +542,7 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                             Some(reverse_order),
                         )
                         .map(CellTransactions)?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 }
             }
             ("index_lock_hash", Some(m)) => {
@@ -563,10 +556,10 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                         .raw_rpc_client
                         .index_lock_hash(hash, index_from.map(BlockNumber::from))
                         .map_err(|err| err.to_string())?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 } else {
                     let resp = self.rpc_client.index_lock_hash(hash, index_from)?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 }
             }
             // [Net]
@@ -578,10 +571,10 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                         .get_banned_addresses()
                         .map(RawBannedAddrList)
                         .map_err(|err| err.to_string())?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 } else {
                     let resp = self.rpc_client.get_banned_addresses().map(BannedAddrList)?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 }
             }
             ("get_peers", Some(m)) => {
@@ -592,10 +585,10 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                         .get_peers()
                         .map(RawNodes)
                         .map_err(|err| err.to_string())?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 } else {
                     let resp = self.rpc_client.get_peers().map(Nodes)?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 }
             }
             ("local_node_info", Some(m)) => {
@@ -605,10 +598,10 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                         .raw_rpc_client
                         .local_node_info()
                         .map_err(|err| err.to_string())?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 } else {
                     let resp = self.rpc_client.local_node_info()?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 }
             }
             ("set_ban", Some(m)) => {
@@ -627,7 +620,7 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                     absolute,
                     reason,
                 )?;
-                Ok(String::from("ok"))
+                Ok(Output::new_success())
             }
             // [Pool]
             ("tx_pool_info", Some(m)) => {
@@ -637,10 +630,10 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                         .raw_rpc_client
                         .tx_pool_info()
                         .map_err(|err| err.to_string())?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 } else {
                     let resp = self.rpc_client.tx_pool_info()?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 }
             }
             // [Stats]
@@ -651,10 +644,10 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                         .raw_rpc_client
                         .get_blockchain_info()
                         .map_err(|err| err.to_string())?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 } else {
                     let resp = self.rpc_client.get_blockchain_info()?;
-                    Ok(resp.render(format, color))
+                    Ok(Output::new_output(resp))
                 }
             }
             // [IntegrationTest]
@@ -663,12 +656,12 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                 let address: Multiaddr =
                     FromStrParser::<Multiaddr>::new().from_matches(m, "address")?;
                 self.rpc_client.add_node(peer_id, address.to_string())?;
-                Ok(String::from("ok"))
+                Ok(Output::new_success())
             }
             ("remove_node", Some(m)) => {
                 let peer_id = m.value_of("peer-id").map(|v| v.to_string()).unwrap();
                 self.rpc_client.remove_node(peer_id)?;
-                Ok(String::from("ok"))
+                Ok(Output::new_success())
             }
             ("broadcast_transaction", Some(m)) => {
                 let json_path: PathBuf = FilePathParser::new(true).from_matches(m, "json-path")?;
@@ -677,7 +670,7 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                     serde_json::from_str(&content).map_err(|err| err.to_string())?;
 
                 let resp = self.rpc_client.broadcast_transaction(tx.into())?;
-                Ok(resp.render(format, color))
+                Ok(Output::new_output(resp))
             }
             _ => Err(Self::subcommand().generate_usage()),
         }

--- a/src/subcommands/tx.rs
+++ b/src/subcommands/tx.rs
@@ -25,7 +25,7 @@ use clap::{App, Arg, ArgMatches};
 use faster_hex::hex_string;
 use serde_derive::{Deserialize, Serialize};
 
-use super::CliSubCommand;
+use super::{CliSubCommand, Output};
 use crate::utils::{
     arg,
     arg_parser::{
@@ -36,7 +36,6 @@ use crate::utils::{
         check_capacity, get_genesis_info, get_live_cell, get_live_cell_with_cache,
         get_network_type, get_privkey_signer, get_to_data, read_password, serialize_signature,
     },
-    printer::{OutputFormat, Printable},
 };
 
 pub struct TxSubCommand<'a> {
@@ -239,13 +238,7 @@ impl<'a> TxSubCommand<'a> {
 }
 
 impl<'a> CliSubCommand for TxSubCommand<'a> {
-    fn process(
-        &mut self,
-        matches: &ArgMatches,
-        format: OutputFormat,
-        color: bool,
-        debug: bool,
-    ) -> Result<String, String> {
+    fn process(&mut self, matches: &ArgMatches, debug: bool) -> Result<Output, String> {
         let network = get_network_type(self.rpc_client)?;
 
         match matches.subcommand() {
@@ -261,9 +254,9 @@ impl<'a> CliSubCommand for TxSubCommand<'a> {
                         serde_json::to_string_pretty(&repr).map_err(|err| err.to_string())?;
                     file.write_all(content.as_bytes())
                         .map_err(|err| err.to_string())?;
-                    Ok(String::from("ok"))
+                    Ok(Output::new_success())
                 } else {
-                    Ok(repr.render(format, color))
+                    Ok(Output::new_output(repr))
                 }
             }
             ("clear-field", Some(m)) => {
@@ -278,7 +271,7 @@ impl<'a> CliSubCommand for TxSubCommand<'a> {
                     }
                     Ok(())
                 })?;
-                Ok(String::from("ok"))
+                Ok(Output::new_success())
             }
             ("add-input", Some(m)) => {
                 let tx_file: PathBuf = FilePathParser::new(true).from_matches(m, "tx-file")?;
@@ -307,7 +300,7 @@ impl<'a> CliSubCommand for TxSubCommand<'a> {
                     )
                 })?;
 
-                Ok(String::from("ok"))
+                Ok(Output::new_success())
             }
             ("add-output", Some(m)) => {
                 let tx_file: PathBuf = FilePathParser::new(true).from_matches(m, "tx-file")?;
@@ -346,7 +339,7 @@ impl<'a> CliSubCommand for TxSubCommand<'a> {
                     Ok(())
                 })?;
 
-                Ok(String::from("ok"))
+                Ok(Output::new_success())
             }
             ("add-signature", Some(m)) => {
                 let tx_file: PathBuf = FilePathParser::new(true).from_matches(m, "tx-file")?;
@@ -356,7 +349,7 @@ impl<'a> CliSubCommand for TxSubCommand<'a> {
                 modify_tx_file(&tx_file, network, |helper| {
                     helper.add_signature(lock_arg, signature)
                 })?;
-                Ok(String::from("ok"))
+                Ok(Output::new_success())
             }
             ("add-multisig-config", Some(m)) => {
                 let tx_file: PathBuf = FilePathParser::new(false).from_matches(m, "tx-file")?;
@@ -377,7 +370,7 @@ impl<'a> CliSubCommand for TxSubCommand<'a> {
                     helper.add_multisig_config(cfg);
                     Ok(())
                 })?;
-                Ok(String::from("ok"))
+                Ok(Output::new_success())
             }
             ("info", Some(m)) => {
                 let tx_file: PathBuf = FilePathParser::new(false).from_matches(m, "tx-file")?;
@@ -450,7 +443,7 @@ impl<'a> CliSubCommand for TxSubCommand<'a> {
                     "output_total": format!("{:#}", HumanCapacity(output_total)),
                     "tx_fee": tx_fee_string,
                 });
-                Ok(resp.render(format, color))
+                Ok(Output::new_output(resp))
             }
             ("sign-inputs", Some(m)) => {
                 let tx_file: PathBuf = FilePathParser::new(true).from_matches(m, "tx-file")?;
@@ -499,7 +492,7 @@ impl<'a> CliSubCommand for TxSubCommand<'a> {
                         })
                     })
                     .collect::<Vec<_>>();
-                Ok(resp.render(format, color))
+                Ok(Output::new_output(resp))
             }
             ("send", Some(m)) => {
                 let tx_file: PathBuf = FilePathParser::new(false).from_matches(m, "tx-file")?;
@@ -537,13 +530,16 @@ impl<'a> CliSubCommand for TxSubCommand<'a> {
                 let tx = helper.build_tx(&mut get_live_cell, skip_check)?;
                 let rpc_tx = json_types::Transaction::from(tx.data());
                 if debug {
-                    println!("[send transaction]:\n{}", rpc_tx.render(format, color));
+                    eprintln!(
+                        "[send transaction]:\n{}",
+                        serde_json::to_string_pretty(&rpc_tx).unwrap()
+                    );
                 }
                 let resp = self
                     .rpc_client
                     .send_transaction(tx.data())
                     .map_err(|err| format!("Send transaction error: {}", err))?;
-                Ok(resp.render(format, color))
+                Ok(Output::new_output(resp))
             }
             ("build-multisig-address", Some(m)) => {
                 let sighash_addresses: Vec<Address> = AddressParser::default()
@@ -569,7 +565,7 @@ impl<'a> CliSubCommand for TxSubCommand<'a> {
                     "lock-arg": format!("0x{}", hex_string(address_payload.args().as_ref()).unwrap()),
                     "lock-hash": format!("{:#x}", lock_script.calc_script_hash())
                 });
-                Ok(resp.render(format, color))
+                Ok(Output::new_output(resp))
             }
             _ => Err(Self::subcommand("tx").generate_usage()),
         }
@@ -596,7 +592,7 @@ fn print_cell_info(
     };
     let address = Address::new(network, address_payload);
     let type_script_status = if type_script_empty { "none" } else { "some" };
-    println!(
+    eprintln!(
         "[{}] {} => {}, (data-length: {}, type-script: {}, lock-kind: {})",
         prefix,
         address,


### PR DESCRIPTION
Changes:
- All debug information print to `stderr`
- Print a fixed message to `stderr` indicate the sub-command is success

```yaml
status: success
```

Related issues:
* https://github.com/nervosnetwork/ckb-cli/issues/286
* https://github.com/nervosnetwork/ckb-cli/issues/287
* https://github.com/nervosnetwork/ckb-cli/issues/288