### PR TITLE
feat: Add extended public key to keystore

### DIFF
--- a/ckb-sdk/src/wallet/keystore/mod.rs
+++ b/ckb-sdk/src/wallet/keystore/mod.rs
@@ -906,10 +906,10 @@ impl Drop for MasterPrivKey {
 mod tests {
     use super::*;
     use crate::Address;
-    use ckb_types::h256;
+    use ckb_types::{h160, h256};
 
     #[test]
-    fn test_derived_key_set_by_index() {
+    fn test_derived_key_set() {
         let privkey = h256!("0xd00c06bfd800d27397002dca6fb0993d5ba6399b4238b2f29ee9deb97593d2bc");
         let chain_code =
             h256!("0xcf4ebc9849b0466e82b82075b6b2ffa0b13f85e0825859996776a7350734024a");
@@ -919,7 +919,10 @@ mod tests {
         let master_privkey = MasterPrivKey::from_bytes(data).expect("master privkey");
         let ckb_root = master_privkey.ckb_root();
 
-        let key_set = ckb_root.derived_key_set_by_index(0, 5, 0, 5);
+        let key_set_by_index = ckb_root.derived_key_set_by_index(0, 5, 0, 5);
+        let key_set = ckb_root
+            .derived_key_set(5, &h160!("0xf52462cb98211b44c8e6ccf46866cf0e9f83a857"), 10)
+            .unwrap();
         let external_addrs = vec![
             "ckb1qyqwlkzwj0rnn0cgepgrrmepxdcx28lj7ycqsyff5g",
             "ckb1qyq0z9zf42dqt2dsu2m26tz8uf2pgqt48hzs59gq8k",
@@ -952,6 +955,7 @@ mod tests {
         let external = to_pairs(external_addrs, KeyChain::External);
         let change = to_pairs(change_addrs, KeyChain::Change);
         let expected_key_set = DerivedKeySet { external, change };
+        assert_eq!(key_set, key_set_by_index);
         assert_eq!(key_set, expected_key_set);
     }
 }

--- a/ckb-sdk/src/wallet/keystore/mod.rs
+++ b/ckb-sdk/src/wallet/keystore/mod.rs
@@ -78,12 +78,16 @@ impl KeyStore {
         self.refresh_dir().ok();
         &self.files
     }
-    pub fn get_ckb_root(&mut self, hash160: &H160) -> Option<&CkbRoot> {
-        self.refresh_dir().ok();
+    pub fn get_ckb_root(&mut self, hash160: &H160, refresh: bool) -> Option<&CkbRoot> {
+        if refresh {
+            self.refresh_dir().ok();
+        }
         self.ckb_roots.get(hash160)
     }
-    pub fn has_account(&mut self, hash160: &H160) -> bool {
-        self.refresh_dir().ok();
+    pub fn has_account(&mut self, hash160: &H160, refresh: bool) -> bool {
+        if refresh {
+            self.refresh_dir().ok();
+        }
         self.files.contains_key(hash160)
     }
 

--- a/src/interactive.rs
+++ b/src/interactive.rs
@@ -23,7 +23,7 @@ use crate::utils::{
     other::{check_alerts, get_network_type, index_dirname},
     printer::{ColorWhen, OutputFormat, Printable},
 };
-use ckb_sdk::{rpc::RawHttpRpcClient, GenesisInfo, HttpRpcClient};
+use ckb_sdk::{rpc::RawHttpRpcClient, wallet::KeyStore, GenesisInfo, HttpRpcClient};
 
 const ENV_PATTERN: &str = r"\$\{\s*(?P<key>\S+)\s*\}";
 
@@ -35,6 +35,7 @@ pub struct InteractiveEnv {
     index_dir: PathBuf,
     parser: clap::App<'static>,
     plugin_mgr: PluginManager,
+    key_store: KeyStore,
     rpc_client: HttpRpcClient,
     raw_rpc_client: RawHttpRpcClient,
     index_controller: IndexController,
@@ -46,6 +47,7 @@ impl InteractiveEnv {
         ckb_cli_dir: PathBuf,
         mut config: GlobalConfig,
         plugin_mgr: PluginManager,
+        key_store: KeyStore,
         index_controller: IndexController,
     ) -> Result<InteractiveEnv, String> {
         if !ckb_cli_dir.as_path().exists() {
@@ -79,6 +81,7 @@ impl InteractiveEnv {
             history_file,
             parser,
             plugin_mgr,
+            key_store,
             rpc_client,
             raw_rpc_client,
             index_controller,
@@ -344,7 +347,7 @@ impl InteractiveEnv {
                     Ok(())
                 }
                 ("account", Some(sub_matches)) => {
-                    let output = AccountSubCommand::new(&mut self.plugin_mgr)
+                    let output = AccountSubCommand::new(&mut self.plugin_mgr, &mut self.key_store)
                         .process(&sub_matches, debug)?;
                     output.print(format, color);
                     Ok(())

--- a/src/plugin/builtin.rs
+++ b/src/plugin/builtin.rs
@@ -50,9 +50,9 @@ impl DefaultKeyStore {
                         .map(PluginResponse::H160)
                         .map_err(|err| err.to_string())
                 }
-                KeyStoreRequest::HasAccount(hash160) => {
-                    Ok(PluginResponse::Boolean(keystore.has_account(&hash160)))
-                }
+                KeyStoreRequest::HasAccount(hash160) => Ok(PluginResponse::Boolean(
+                    keystore.has_account(&hash160, true),
+                )),
                 KeyStoreRequest::UpdatePassword {
                     hash160,
                     password,
@@ -111,7 +111,7 @@ impl DefaultKeyStore {
                     let password =
                         password.ok_or_else(|| String::from(ERROR_KEYSTORE_REQUIRE_PASSWORD))?;
                     keystore
-                        .get_ckb_root(&hash160)
+                        .get_ckb_root(&hash160, true)
                         .cloned()
                         .map_or_else(
                             || {
@@ -138,7 +138,7 @@ impl DefaultKeyStore {
                     let password =
                         password.ok_or_else(|| String::from(ERROR_KEYSTORE_REQUIRE_PASSWORD))?;
                     keystore
-                        .get_ckb_root(&hash160)
+                        .get_ckb_root(&hash160, true)
                         .cloned()
                         .map_or_else(
                             || {

--- a/src/subcommands/account.rs
+++ b/src/subcommands/account.rs
@@ -202,7 +202,7 @@ impl<'a> CliSubCommand for AccountSubCommand<'a> {
                                 unreachable!();
                             }
                         } else {
-                            let has_ckb_root = self.key_store.get_ckb_root(&lock_arg).is_some();
+                            let has_ckb_root = self.key_store.get_ckb_root(&lock_arg, false).is_some();
                             serde_json::json!({
                                 "#": idx,
                                 "source": source,

--- a/src/subcommands/account.rs
+++ b/src/subcommands/account.rs
@@ -1,4 +1,3 @@
-use std::cmp::Ordering;
 use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -169,14 +168,7 @@ impl<'a> CliSubCommand for AccountSubCommand<'a> {
                     .map(|(lock_arg, source)| (lock_arg.clone(), source.clone()))
                     .collect::<Vec<(H160, String)>>();
                 // Sort by file path name
-                accounts.sort_by(|a, b| {
-                    let order = a.1.cmp(&b.1);
-                    if order == Ordering::Equal {
-                        a.0.cmp(&b.0)
-                    } else {
-                        order
-                    }
-                });
+                accounts.sort_by(|a, b| a.1.cmp(&b.1));
                 let only_mainnet_address = m.is_present("only-mainnet-address");
                 let only_testnet_address = m.is_present("only-testnet-address");
                 let partial_fields = only_mainnet_address || only_testnet_address;

--- a/src/subcommands/wallet/mod.rs
+++ b/src/subcommands/wallet/mod.rs
@@ -596,6 +596,7 @@ impl<'a> CliSubCommand for WalletSubCommand<'a> {
                     let mut lock_hashes = vec![Script::from(&address_payload).calc_script_hash()];
                     if m.is_present("derived") {
                         let lock_arg = H160::from_slice(address_payload.args().as_ref()).unwrap();
+
                         let key_set = self
                             .plugin_mgr
                             .keystore_handler()


### PR DESCRIPTION
So, no need password to use sub-command like `account bip44-addresses`.

* Add `ckb_root` field to keystore json file
* Add `account upgrade` sub-command to update keystore json to latest format