### PR TITLE
feat: Sign and verfiy message use extended key

### DIFF
--- a/src/plugin/manager.rs
+++ b/src/plugin/manager.rs
@@ -1376,13 +1376,14 @@ impl KeyStoreHandler {
         external_max_len: u32,
         change_last: H160,
         change_max_len: u32,
+        password: Option<String>,
     ) -> Result<DerivedKeySet, String> {
         let request = KeyStoreRequest::DerivedKeySet {
             hash160: hash160.clone(),
             external_max_len,
             change_last: change_last.clone(),
             change_max_len,
-            password: None,
+            password,
         };
         let resp = match self.call(request) {
             Ok(resp) => resp,
@@ -1417,6 +1418,7 @@ impl KeyStoreHandler {
         external_length: u32,
         change_start: u32,
         change_length: u32,
+        password: Option<String>,
     ) -> Result<DerivedKeySet, String> {
         let request = KeyStoreRequest::DerivedKeySetByIndex {
             hash160: hash160.clone(),
@@ -1424,7 +1426,7 @@ impl KeyStoreHandler {
             external_length,
             change_start,
             change_length,
-            password: None,
+            password,
         };
         let resp = match self.call(request) {
             Ok(resp) => resp,

--- a/src/subcommands/account.rs
+++ b/src/subcommands/account.rs
@@ -378,6 +378,7 @@ impl<'a> CliSubCommand for AccountSubCommand<'a> {
                         receiving_length,
                         from_change_index,
                         change_length,
+                        None,
                     )?;
                 let get_addresses = |set: &[(DerivationPath, H160)]| {
                     set.iter()

--- a/src/subcommands/wallet/mod.rs
+++ b/src/subcommands/wallet/mod.rs
@@ -300,6 +300,7 @@ impl<'a> WalletSubCommand<'a> {
                     receiving_address_length,
                     change_last.clone(),
                     DERIVE_CHANGE_ADDRESS_MAX_LEN,
+                    None,
                 )?;
                 let mut change_path_opt = None;
                 for (path, hash160) in key_set.external.iter().chain(key_set.change.iter()) {
@@ -606,6 +607,7 @@ impl<'a> CliSubCommand for WalletSubCommand<'a> {
                                 receiving_address_length,
                                 0,
                                 change_address_length,
+                                None,
                             )?;
                         for (_, hash160) in key_set.external.iter().chain(key_set.change.iter()) {
                             let payload = AddressPayload::from_pubkey_hash(hash160.clone());


### PR DESCRIPTION
NOTE: Waiting https://github.com/nervosnetwork/ckb-cli/pull/313

Adding `--extended-address` to:
- `util sign-data` 
- `util sign-message`
- `util verify-message`