### PR TITLE
feat: Add account import-from-plugin sub-command

### DIFF
--- a/plugin-protocol/examples/keystore.rs
+++ b/plugin-protocol/examples/keystore.rs
@@ -1,4 +1,4 @@
-use ckb_types::{h160, H160};
+use ckb_types::{h160, h256, H160, H256};
 
 use ckb_cli_plugin_protocol::{
     JsonrpcError, JsonrpcRequest, JsonrpcResponse, KeyStoreRequest, PluginConfig, PluginRequest,
@@ -71,11 +71,11 @@ fn handle(request: PluginRequest) -> Option<PluginResponse> {
                     }
 
                     let accounts = vec![
-                        h160!("0xe22f7f385830a75e50ab7fc5fd4c35b134f1e84b"),
-                        h160!("0x13e41d6F9292555916f17B4882a5477C01270142"),
-                        h160!("0xb39bbc0b3673c7d36450bc14cfcdad2d559c6c64"),
+                        JsonBytes::from_vec(h160!("0xe22f7f385830a75e50ab7fc5fd4c35b134f1e84b").as_bytes().to_vec()),
+                        JsonBytes::from_vec(h256!("0x1111111f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8").as_bytes().to_vec()),
+                        JsonBytes::from_vec(h256!("0x2222222b0857efc65e1bca0c07df34c31663b3622fd3876c876320fc9634e2a8").as_bytes().to_vec()),
                     ];
-                    PluginResponse::H160Vec(accounts)
+                    PluginResponse::BytesVec(accounts)
                 }
                 KeyStoreRequest::HasAccount(_) => PluginResponse::Boolean(true),
                 KeyStoreRequest::CreateAccount(_) => {
@@ -84,6 +84,13 @@ fn handle(request: PluginRequest) -> Option<PluginResponse> {
                 KeyStoreRequest::UpdatePassword { .. } => PluginResponse::Ok,
                 KeyStoreRequest::Import { .. } => {
                     PluginResponse::H160(h160!("0xb39bbc0b3673c7d36450bc14cfcdad2d559c6c64"))
+                }
+                KeyStoreRequest::ImportAccount { account_id, .. } => {
+                    eprintln!(
+                        "account_id: {}",
+                        serde_json::to_string_pretty(&account_id).unwrap()
+                    );
+                    PluginResponse::H160(h160!("0x1111111111111111111222222222222222222222"))
                 }
                 KeyStoreRequest::Export { .. } => PluginResponse::MasterPrivateKey {
                     privkey: JsonBytes::from_vec(vec![3u8; 32]),

--- a/plugin-protocol/examples/keystore_no_password.rs
+++ b/plugin-protocol/examples/keystore_no_password.rs
@@ -54,7 +54,11 @@ fn handle(request: PluginRequest) -> Option<PluginResponse> {
                         h160!("0x13e41d6F9292555916f17B4882a5477C01270142"),
                         h160!("0xb39bbc0b3673c7d36450bc14cfcdad2d559c6c64"),
                     ];
-                    PluginResponse::H160Vec(accounts)
+                    let accounts = accounts
+                        .into_iter()
+                        .map(|hash160| JsonBytes::from_vec(hash160.as_bytes().to_vec()))
+                        .collect::<Vec<_>>();
+                    PluginResponse::BytesVec(accounts)
                 }
                 KeyStoreRequest::HasAccount(_) => PluginResponse::Boolean(true),
                 KeyStoreRequest::CreateAccount(_) => {
@@ -63,6 +67,9 @@ fn handle(request: PluginRequest) -> Option<PluginResponse> {
                 KeyStoreRequest::UpdatePassword { .. } => PluginResponse::Ok,
                 KeyStoreRequest::Import { .. } => {
                     PluginResponse::H160(h160!("0xb39bbc0b3673c7d36450bc14cfcdad2d559c6c64"))
+                }
+                KeyStoreRequest::ImportAccount { .. } => {
+                    PluginResponse::H160(h160!("0x1111111111111111111222222222222222222222"))
                 }
                 KeyStoreRequest::Export { .. } => PluginResponse::MasterPrivateKey {
                     privkey: JsonBytes::from_vec(vec![3u8; 32]),

--- a/plugin-protocol/src/lib.rs
+++ b/plugin-protocol/src/lib.rs
@@ -117,6 +117,7 @@ pub enum PluginResponse {
     BlockViewOpt(Box<Option<BlockView>>),
     BlockRewardOpt(Option<BlockReward>),
     Bytes(JsonBytes),
+    BytesVec(Vec<JsonBytes>),
 
     Callback(CallbackResponse),
     MasterPrivateKey {
@@ -179,7 +180,7 @@ pub enum SignTarget {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub enum KeyStoreRequest {
-    // return: PluginResponse::H160
+    // return: PluginResponse::Bytes
     ListAccount,
     // return: PluginResponse::Boolean
     HasAccount(H160),
@@ -195,6 +196,11 @@ pub enum KeyStoreRequest {
     Import {
         privkey: [u8; 32],
         chain_code: [u8; 32],
+        password: Option<String>,
+    },
+    // return: PluginResponse::H160
+    ImportAccount {
+        account_id: JsonBytes,
         password: Option<String>,
     },
     // return: PluginResponse::MasterPrivateKey

--- a/plugin-protocol/src/method.rs
+++ b/plugin-protocol/src/method.rs
@@ -31,6 +31,7 @@ pub const KEYSTORE_HAS_ACCOUNT: &str = "keystore_has_account";
 pub const KEYSTORE_CREATE_ACCOUNT: &str = "keystore_create_account";
 pub const KEYSTORE_UPDATE_PASSWORD: &str = "keystore_update_password";
 pub const KEYSTORE_IMPORT: &str = "keystore_import";
+pub const KEYSTORE_IMPORT_ACCOUNT: &str = "keystore_import_account";
 pub const KEYSTORE_EXPORT: &str = "keystore_export";
 pub const KEYSTORE_SIGN: &str = "keystore_sign";
 pub const KEYSTORE_EXTENDED_PUBKEY: &str = "keystore_extended_pubkey";

--- a/src/plugin/builtin.rs
+++ b/src/plugin/builtin.rs
@@ -82,6 +82,9 @@ impl DefaultKeyStore {
                         .map_err(|err| err.to_string())?;
                     Ok(PluginResponse::H160(lock_arg))
                 }
+                KeyStoreRequest::ImportAccount { .. } => {
+                    Err("Not supported in file based keystore".to_string())
+                }
                 KeyStoreRequest::Export { hash160, password } => {
                     let password = password.ok_or_else(|| {
                         String::from("Password is required by default keystore: export key")

--- a/src/plugin/manager.rs
+++ b/src/plugin/manager.rs
@@ -10,7 +10,7 @@ use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 
 use ckb_index::LiveCellInfo;
-use ckb_jsonrpc_types::{BlockNumber, HeaderView, Script};
+use ckb_jsonrpc_types::{BlockNumber, HeaderView, JsonBytes, Script};
 use ckb_sdk::{
     wallet::{ChildNumber, DerivationPath, DerivedKeySet, MasterPrivKey},
     HttpRpcClient,
@@ -1193,6 +1193,9 @@ impl KeyStoreHandler {
                 // Default only
                 default_only = true;
             }
+            KeyStoreRequest::ImportAccount { .. } => {
+                // Plugin only
+            }
             KeyStoreRequest::Export { ref hash160, .. } => {
                 // Both
                 hash160_opt = Some(hash160.clone());
@@ -1262,7 +1265,7 @@ impl KeyStoreHandler {
         }
     }
 
-    pub fn list_account(&self) -> Result<Vec<(H160, String)>, String> {
+    pub fn list_account(&self) -> Result<Vec<(Bytes, String)>, String> {
         let request = KeyStoreRequest::ListAccount;
         let plugin_request = PluginRequest::KeyStore(request.clone());
 
@@ -1273,17 +1276,18 @@ impl KeyStoreHandler {
             all_accounts.extend(
                 accounts
                     .into_iter()
-                    .map(|hash160| (hash160, ACCOUNT_SOURCE_FS.to_owned())),
+                    .map(|hash160| Bytes::from(hash160.as_bytes().to_vec()))
+                    .map(|data| (data, ACCOUNT_SOURCE_FS.to_owned())),
             );
         } else {
             return Err("Mismatch default keystore response".to_string());
         }
         if let Some(cfg) = self.actived_plugin() {
-            if let PluginResponse::H160Vec(accounts) = self.call(request)? {
+            if let PluginResponse::BytesVec(accounts) = self.call(request)? {
                 all_accounts.extend(
                     accounts
                         .into_iter()
-                        .map(|hash160| (hash160, format!("[plugin]: {}", cfg.name))),
+                        .map(|data| (data.into_bytes(), format!("[plugin]: {}", cfg.name))),
                 );
             } else {
                 return Err("Mismatch plugin keystore response".to_string());
@@ -1330,6 +1334,21 @@ impl KeyStoreHandler {
         let request = KeyStoreRequest::Import {
             privkey,
             chain_code,
+            password,
+        };
+        if let PluginResponse::H160(lock_arg) = self.call(request)? {
+            Ok(lock_arg)
+        } else {
+            Err("Mismatch keystore response".to_string())
+        }
+    }
+    pub fn import_account(
+        &self,
+        account_id: Bytes,
+        password: Option<String>,
+    ) -> Result<H160, String> {
+        let request = KeyStoreRequest::ImportAccount {
+            account_id: JsonBytes::from_bytes(account_id),
             password,
         };
         if let PluginResponse::H160(lock_arg) = self.call(request)? {

--- a/src/subcommands/account.rs
+++ b/src/subcommands/account.rs
@@ -8,6 +8,7 @@ use ckb_sdk::{
 };
 use ckb_types::{packed::Script, prelude::*, H160, H256};
 use clap::{App, Arg, ArgMatches};
+use faster_hex::hex_string;
 
 use super::{CliSubCommand, Output};
 use crate::plugin::PluginManager;
@@ -15,7 +16,7 @@ use crate::utils::{
     arg::lock_arg,
     arg_parser::{
         ArgParser, ExtendedPrivkeyPathParser, FilePathParser, FixedHashParser, FromStrParser,
-        PrivkeyPathParser, PrivkeyWrapper,
+        HexParser, PrivkeyPathParser, PrivkeyWrapper,
     },
     other::read_password,
 };
@@ -73,6 +74,23 @@ impl<'a> AccountSubCommand<'a> {
                          .clone()
                          .required_unless("privkey-path")
                          .validator(|input| ExtendedPrivkeyPathParser.validate(input))
+                    ),
+                App::new("import-from-plugin")
+                    .about("Import an account from keystore plugin")
+                    .arg(
+                        Arg::with_name("account-id")
+                            .long("account-id")
+                            .takes_value(true)
+                            .required(true)
+                            .validator(|input| {
+                                let hex = HexParser.parse(input)?;
+                                if hex.is_empty() {
+                                    Err("empty account id is not allowed".to_string())
+                                } else {
+                                    Ok(())
+                                }
+                            })
+                            .about("The account id (hex format, can be found in account list)")
                     ),
                 App::new("import-keystore")
                     .about("Import key from encrypted keystore json file and create a new account.")
@@ -160,13 +178,7 @@ impl<'a> CliSubCommand for AccountSubCommand<'a> {
     fn process(&mut self, matches: &ArgMatches, _debug: bool) -> Result<Output, String> {
         match matches.subcommand() {
             ("list", Some(m)) => {
-                let mut accounts = self
-                    .plugin_mgr
-                    .keystore_handler()
-                    .list_account()?
-                    .iter()
-                    .map(|(lock_arg, source)| (lock_arg.clone(), source.clone()))
-                    .collect::<Vec<(H160, String)>>();
+                let mut accounts = self.plugin_mgr.keystore_handler().list_account()?;
                 // Sort by file path name
                 accounts.sort_by(|a, b| a.1.cmp(&b.1));
                 let only_mainnet_address = m.is_present("only-mainnet-address");
@@ -175,36 +187,45 @@ impl<'a> CliSubCommand for AccountSubCommand<'a> {
                 let resp = accounts
                     .into_iter()
                     .enumerate()
-                    .map(|(idx, (lock_arg, source))| {
-                        let address_payload = AddressPayload::from_pubkey_hash(lock_arg.clone());
-                        let lock_hash: H256 = Script::from(&address_payload)
-                            .calc_script_hash()
-                            .unpack();
-                        if partial_fields {
-                            let key = format!("{:#x}", lock_arg);
-                            if only_mainnet_address {
-                                serde_json::json!({
-                                    key: Address::new(NetworkType::Mainnet, address_payload).to_string()
-                                })
-                            } else if only_testnet_address {
-                                serde_json::json!({
-                                    key: Address::new(NetworkType::Testnet, address_payload).to_string()
-                                })
+                    .map(|(idx, (data, source))| {
+                        if data.len() == 20 {
+                            let lock_arg = H160::from_slice(data.as_ref()).expect("H160");
+                            let address_payload = AddressPayload::from_pubkey_hash(lock_arg.clone());
+                            let lock_hash: H256 = Script::from(&address_payload)
+                                .calc_script_hash()
+                                .unpack();
+                            if partial_fields {
+                                let key = format!("{:#x}", lock_arg);
+                                if only_mainnet_address {
+                                    serde_json::json!({
+                                        key: Address::new(NetworkType::Mainnet, address_payload).to_string()
+                                    })
+                                } else if only_testnet_address {
+                                    serde_json::json!({
+                                        key: Address::new(NetworkType::Testnet, address_payload).to_string()
+                                    })
+                                } else {
+                                    unreachable!();
+                                }
                             } else {
-                                unreachable!();
+                                let has_ckb_root = self.key_store.get_ckb_root(&lock_arg, false).is_some();
+                                serde_json::json!({
+                                    "#": idx,
+                                    "source": source,
+                                    "lock_arg": format!("{:#x}", lock_arg),
+                                    "lock_hash": format!("{:#x}", lock_hash),
+                                    "has_ckb_root": has_ckb_root,
+                                    "address": {
+                                        "mainnet": Address::new(NetworkType::Mainnet, address_payload.clone()).to_string(),
+                                        "testnet": Address::new(NetworkType::Testnet, address_payload).to_string(),
+                                    },
+                                })
                             }
                         } else {
-                            let has_ckb_root = self.key_store.get_ckb_root(&lock_arg, false).is_some();
                             serde_json::json!({
                                 "#": idx,
                                 "source": source,
-                                "lock_arg": format!("{:#x}", lock_arg),
-                                "lock_hash": format!("{:#x}", lock_hash),
-                                "has_ckb_root": has_ckb_root,
-                                "address": {
-                                    "mainnet": Address::new(NetworkType::Mainnet, address_payload.clone()).to_string(),
-                                    "testnet": Address::new(NetworkType::Testnet, address_payload).to_string(),
-                                },
+                                "account-id": format!("0x{}", hex_string(data.as_ref()).expect("hex")),
                             })
                         }
                     })
@@ -260,7 +281,28 @@ impl<'a> CliSubCommand for AccountSubCommand<'a> {
                     .import_key(master_privkey, password)?;
                 let address_payload = AddressPayload::from_pubkey_hash(lock_arg.clone());
                 let resp = serde_json::json!({
-                    "lock_arg": format!("{:x}", lock_arg),
+                    "lock_arg": format!("{:#x}", lock_arg),
+                    "address": {
+                        "mainnet": Address::new(NetworkType::Mainnet, address_payload.clone()).to_string(),
+                        "testnet": Address::new(NetworkType::Testnet, address_payload).to_string(),
+                    },
+                });
+                Ok(Output::new_output(resp))
+            }
+            ("import-from-plugin", Some(m)) => {
+                let account_id: Vec<u8> = HexParser.from_matches(m, "account-id")?;
+                let password = if self.plugin_mgr.keystore_require_password() {
+                    Some(read_password(false, None)?)
+                } else {
+                    None
+                };
+                let lock_arg = self
+                    .plugin_mgr
+                    .keystore_handler()
+                    .import_account(account_id.into(), password)?;
+                let address_payload = AddressPayload::from_pubkey_hash(lock_arg.clone());
+                let resp = serde_json::json!({
+                    "lock_arg": format!("{:#x}", lock_arg),
                     "address": {
                         "mainnet": Address::new(NetworkType::Mainnet, address_payload.clone()).to_string(),
                         "testnet": Address::new(NetworkType::Testnet, address_payload).to_string(),

--- a/test/src/spec/plugin.rs
+++ b/test/src/spec/plugin.rs
@@ -41,6 +41,14 @@ impl Spec for Plugin {
             "0x59fbdd52b9967b47270b207d352e6f59616a2f03b24a9710c087b379ac0f8d09"
         );
 
+        let output = setup
+            .cli("account import-from-plugin --account-id 0x1111111f3ecf4be0f2fcd2188b23f1b9fcc88e5d4b65a8637b17723bbda3cce8");
+        let value: serde_yaml::Value = serde_yaml::from_str(&output).unwrap();
+        assert_eq!(
+            value["lock_arg"],
+            "0x1111111111111111111222222222222222222222"
+        );
+
         let tempdir = tempdir().expect("create tempdir failed");
         let extended_privkey_path = format!(
             "{}/exported-privkey",


### PR DESCRIPTION
`import-from-plugin` subcommand import the public key and chain code of `m/44'/309'/0'` to local file system, so we can use this information do public key derivation without the permission of ledger device. The ledger plugin save this information in `~/.ckb-cli/ledger-keystore/`