### PR TITLE
chore: Update ckb to v0.34

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -330,13 +330,13 @@ dependencies = [
 
 [[package]]
 name = "ckb-build-info"
-version = "0.33.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?tag=v0.33.0-pre1#b7e57a0e1c612861500fa3504e0eeb9f419b0050"
+version = "0.34.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?tag=v0.34.0-rc1#673fd25518f9e9cea8814b9870758a8e7ba7dc14"
 
 [[package]]
 name = "ckb-chain-spec"
-version = "0.33.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?tag=v0.33.0-pre1#b7e57a0e1c612861500fa3504e0eeb9f419b0050"
+version = "0.34.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?tag=v0.34.0-rc1#673fd25518f9e9cea8814b9870758a8e7ba7dc14"
 dependencies = [
  "ckb-crypto",
  "ckb-dao-utils",
@@ -354,7 +354,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-cli"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "ansi_term 0.11.0",
  "atty",
@@ -419,8 +419,8 @@ dependencies = [
 
 [[package]]
 name = "ckb-crypto"
-version = "0.33.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?tag=v0.33.0-pre1#b7e57a0e1c612861500fa3504e0eeb9f419b0050"
+version = "0.34.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?tag=v0.34.0-rc1#673fd25518f9e9cea8814b9870758a8e7ba7dc14"
 dependencies = [
  "ckb-fixed-hash",
  "failure",
@@ -432,8 +432,8 @@ dependencies = [
 
 [[package]]
 name = "ckb-dao-utils"
-version = "0.33.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?tag=v0.33.0-pre1#b7e57a0e1c612861500fa3504e0eeb9f419b0050"
+version = "0.34.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?tag=v0.34.0-rc1#673fd25518f9e9cea8814b9870758a8e7ba7dc14"
 dependencies = [
  "byteorder",
  "ckb-error",
@@ -444,8 +444,8 @@ dependencies = [
 
 [[package]]
 name = "ckb-error"
-version = "0.33.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?tag=v0.33.0-pre1#b7e57a0e1c612861500fa3504e0eeb9f419b0050"
+version = "0.34.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?tag=v0.34.0-rc1#673fd25518f9e9cea8814b9870758a8e7ba7dc14"
 dependencies = [
  "ckb-occupied-capacity",
  "enum-display-derive",
@@ -455,8 +455,8 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash"
-version = "0.33.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?tag=v0.33.0-pre1#b7e57a0e1c612861500fa3504e0eeb9f419b0050"
+version = "0.34.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?tag=v0.34.0-rc1#673fd25518f9e9cea8814b9870758a8e7ba7dc14"
 dependencies = [
  "ckb-fixed-hash-core",
  "ckb-fixed-hash-hack",
@@ -465,8 +465,8 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash-core"
-version = "0.33.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?tag=v0.33.0-pre1#b7e57a0e1c612861500fa3504e0eeb9f419b0050"
+version = "0.34.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?tag=v0.34.0-rc1#673fd25518f9e9cea8814b9870758a8e7ba7dc14"
 dependencies = [
  "failure",
  "faster-hex 0.4.1",
@@ -475,8 +475,8 @@ dependencies = [
 
 [[package]]
 name = "ckb-fixed-hash-hack"
-version = "0.33.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?tag=v0.33.0-pre1#b7e57a0e1c612861500fa3504e0eeb9f419b0050"
+version = "0.34.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?tag=v0.34.0-rc1#673fd25518f9e9cea8814b9870758a8e7ba7dc14"
 dependencies = [
  "ckb-fixed-hash-core",
  "proc-macro-hack",
@@ -487,15 +487,15 @@ dependencies = [
 
 [[package]]
 name = "ckb-hash"
-version = "0.33.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?tag=v0.33.0-pre1#b7e57a0e1c612861500fa3504e0eeb9f419b0050"
+version = "0.34.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?tag=v0.34.0-rc1#673fd25518f9e9cea8814b9870758a8e7ba7dc14"
 dependencies = [
  "blake2b-rs",
 ]
 
 [[package]]
 name = "ckb-index"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "bincode",
  "ckb-rocksdb",
@@ -509,8 +509,8 @@ dependencies = [
 
 [[package]]
 name = "ckb-jsonrpc-types"
-version = "0.33.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?tag=v0.33.0-pre1#b7e57a0e1c612861500fa3504e0eeb9f419b0050"
+version = "0.34.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?tag=v0.34.0-rc1#673fd25518f9e9cea8814b9870758a8e7ba7dc14"
 dependencies = [
  "ckb-types",
  "faster-hex 0.4.1",
@@ -532,17 +532,17 @@ dependencies = [
 
 [[package]]
 name = "ckb-logger"
-version = "0.33.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?tag=v0.33.0-pre1#b7e57a0e1c612861500fa3504e0eeb9f419b0050"
+version = "0.34.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?tag=v0.34.0-rc1#673fd25518f9e9cea8814b9870758a8e7ba7dc14"
 dependencies = [
  "ansi_term 0.12.1",
  "backtrace",
  "chrono",
+ "ckb-util",
  "crossbeam-channel",
  "env_logger",
  "lazy_static",
  "log 0.4.8",
- "parking_lot 0.7.1",
  "regex",
  "sentry",
  "serde",
@@ -551,8 +551,8 @@ dependencies = [
 
 [[package]]
 name = "ckb-occupied-capacity"
-version = "0.33.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?tag=v0.33.0-pre1#b7e57a0e1c612861500fa3504e0eeb9f419b0050"
+version = "0.34.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?tag=v0.34.0-rc1#673fd25518f9e9cea8814b9870758a8e7ba7dc14"
 dependencies = [
  "ckb-occupied-capacity-core",
  "ckb-occupied-capacity-macros",
@@ -561,16 +561,16 @@ dependencies = [
 
 [[package]]
 name = "ckb-occupied-capacity-core"
-version = "0.33.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?tag=v0.33.0-pre1#b7e57a0e1c612861500fa3504e0eeb9f419b0050"
+version = "0.34.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?tag=v0.34.0-rc1#673fd25518f9e9cea8814b9870758a8e7ba7dc14"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "ckb-occupied-capacity-macros"
-version = "0.33.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?tag=v0.33.0-pre1#b7e57a0e1c612861500fa3504e0eeb9f419b0050"
+version = "0.34.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?tag=v0.34.0-rc1#673fd25518f9e9cea8814b9870758a8e7ba7dc14"
 dependencies = [
  "ckb-occupied-capacity-core",
  "proc-macro-hack",
@@ -580,8 +580,8 @@ dependencies = [
 
 [[package]]
 name = "ckb-pow"
-version = "0.33.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?tag=v0.33.0-pre1#b7e57a0e1c612861500fa3504e0eeb9f419b0050"
+version = "0.34.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?tag=v0.34.0-rc1#673fd25518f9e9cea8814b9870758a8e7ba7dc14"
 dependencies = [
  "byteorder",
  "ckb-hash",
@@ -592,16 +592,16 @@ dependencies = [
 
 [[package]]
 name = "ckb-rational"
-version = "0.33.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?tag=v0.33.0-pre1#b7e57a0e1c612861500fa3504e0eeb9f419b0050"
+version = "0.34.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?tag=v0.34.0-rc1#673fd25518f9e9cea8814b9870758a8e7ba7dc14"
 dependencies = [
  "numext-fixed-uint",
 ]
 
 [[package]]
 name = "ckb-resource"
-version = "0.33.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?tag=v0.33.0-pre1#b7e57a0e1c612861500fa3504e0eeb9f419b0050"
+version = "0.34.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?tag=v0.34.0-rc1#673fd25518f9e9cea8814b9870758a8e7ba7dc14"
 dependencies = [
  "ckb-system-scripts",
  "ckb-types",
@@ -625,8 +625,8 @@ dependencies = [
 
 [[package]]
 name = "ckb-script"
-version = "0.33.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?tag=v0.33.0-pre1#b7e57a0e1c612861500fa3504e0eeb9f419b0050"
+version = "0.34.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?tag=v0.34.0-rc1#673fd25518f9e9cea8814b9870758a8e7ba7dc14"
 dependencies = [
  "byteorder",
  "ckb-chain-spec",
@@ -645,15 +645,15 @@ dependencies = [
 
 [[package]]
 name = "ckb-script-data-loader"
-version = "0.33.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?tag=v0.33.0-pre1#b7e57a0e1c612861500fa3504e0eeb9f419b0050"
+version = "0.34.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?tag=v0.34.0-rc1#673fd25518f9e9cea8814b9870758a8e7ba7dc14"
 dependencies = [
  "ckb-types",
 ]
 
 [[package]]
 name = "ckb-sdk"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "aes-ctr",
  "bech32",
@@ -684,7 +684,7 @@ dependencies = [
 
 [[package]]
 name = "ckb-sdk-types"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "ckb-crypto",
  "ckb-error",
@@ -711,8 +711,8 @@ dependencies = [
 
 [[package]]
 name = "ckb-types"
-version = "0.33.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?tag=v0.33.0-pre1#b7e57a0e1c612861500fa3504e0eeb9f419b0050"
+version = "0.34.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?tag=v0.34.0-rc1#673fd25518f9e9cea8814b9870758a8e7ba7dc14"
 dependencies = [
  "bit-vec",
  "bytes 0.5.4",
@@ -731,8 +731,8 @@ dependencies = [
 
 [[package]]
 name = "ckb-util"
-version = "0.33.0-pre"
-source = "git+https://github.com/nervosnetwork/ckb?tag=v0.33.0-pre1#b7e57a0e1c612861500fa3504e0eeb9f419b0050"
+version = "0.34.0-pre"
+source = "git+https://github.com/nervosnetwork/ckb?tag=v0.34.0-rc1#673fd25518f9e9cea8814b9870758a8e7ba7dc14"
 dependencies = [
  "linked-hash-map 0.5.1",
  "parking_lot 0.7.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "ckb-cli"
-version = "0.33.1"
+version = "0.34.0"
 license = "MIT"
 authors = ["Linfeng Qian <thewawar@gmail.com>", "Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 
 [dependencies]
-ckb-jsonrpc-types = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1" }
-ckb-hash = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1" }
-ckb-crypto = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1", features = ["secp"] }
-ckb-build-info = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1" }
-ckb-types = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1" }
-ckb-util = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1" }
-ckb-resource = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1" }
-ckb-dao-utils = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1" }
+ckb-jsonrpc-types = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1" }
+ckb-hash = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1" }
+ckb-crypto = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1", features = ["secp"] }
+ckb-build-info = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1" }
+ckb-types = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1" }
+ckb-util = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1" }
+ckb-resource = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1" }
+ckb-dao-utils = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1" }
 ckb-sdk = { path = "ckb-sdk" }
 ckb-index = { path = "ckb-index" }
 plugin-protocol = { path = "plugin-protocol", package = "ckb-cli-plugin-protocol" }
@@ -56,7 +56,7 @@ tui = "0.6.0"
 termion = "1.5"
 
 [build-dependencies]
-ckb-build-info = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1" }
+ckb-build-info = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1" }
 
 [workspace]
 members = ["ckb-sdk", "ckb-index", "ckb-sdk-types", "plugin-protocol"]

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ci: fmt clippy test security-audit
 	git diff --exit-code Cargo.lock
 
 integration:
-	bash devtools/ci/integration.sh v0.33.0-pre1
+	bash devtools/ci/integration.sh v0.34.0-rc1
 
 prod: ## Build binary with release profile.
 	cargo build --release

--- a/ckb-index/Cargo.toml
+++ b/ckb-index/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-index"
-version = "0.33.1"
+version = "0.34.0"
 authors = ["Linfeng Qian <thewawar@gmail.com>", "Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 license = "MIT"
@@ -11,6 +11,6 @@ serde_derive = "1.0"
 bincode = "1.1.4"
 log = "0.4.6"
 failure = "0.1.5"
-ckb-types = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1" }
+ckb-types = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1" }
 ckb-sdk = { path = "../ckb-sdk" }
 rocksdb = { package = "ckb-rocksdb", version = "=0.13.0", features = ["snappy"] }

--- a/ckb-sdk-types/Cargo.toml
+++ b/ckb-sdk-types/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-sdk-types"
-version = "0.33.1"
+version = "0.34.0"
 authors = ["Linfeng Qian <thewawar@gmail.com>", "Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 license = "MIT"
@@ -9,14 +9,14 @@ license = "MIT"
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 
-ckb-types = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1" }
-ckb-script = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1", default-features = false }
-ckb-jsonrpc-types = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1" }
-ckb-hash = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1" }
-ckb-error = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1" }
+ckb-types = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1" }
+ckb-script = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1", default-features = false }
+ckb-jsonrpc-types = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1" }
+ckb-hash = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1" }
+ckb-error = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1" }
 
 [dev-dependencies]
-ckb-crypto = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1", features = ["secp"] }
+ckb-crypto = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1", features = ["secp"] }
 
 [features]
 default = ["ckb-script/default"]

--- a/ckb-sdk/Cargo.toml
+++ b/ckb-sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ckb-sdk"
-version = "0.33.1"
+version = "0.34.0"
 authors = ["Linfeng Qian <thewawar@gmail.com>", "Nervos Core Dev <dev@nervos.org>"]
 edition = "2018"
 license = "MIT"
@@ -25,10 +25,10 @@ uuid = { version = "0.7.4", features = ["v4"] }
 chrono = "0.4.6"
 failure = "0.1.5"
 
-ckb-types = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1" }
-ckb-script = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1" }
-ckb-jsonrpc-types = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1" }
-ckb-hash = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1" }
-ckb-resource = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1" }
-ckb-crypto = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1", features = ["secp"] }
+ckb-types = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1" }
+ckb-script = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1" }
+ckb-jsonrpc-types = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1" }
+ckb-hash = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1" }
+ckb-resource = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1" }
+ckb-crypto = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1", features = ["secp"] }
 ckb-sdk-types = { path = "../ckb-sdk-types" }

--- a/ckb-sdk/src/rpc/client.rs
+++ b/ckb-sdk/src/rpc/client.rs
@@ -1,8 +1,8 @@
 use ckb_jsonrpc_types::{
     BannedAddr, Block, BlockNumber, BlockReward, BlockTemplate, BlockView, CellOutputWithOutPoint,
     CellTransaction, CellWithStatus, ChainInfo, EpochNumber, EpochView, HeaderView, LiveCell,
-    LockHashIndexState, Node, OutPoint, PeerState, Timestamp, Transaction, TransactionWithStatus,
-    TxPoolInfo, Uint64, Version,
+    LocalNode, LockHashIndexState, OutPoint, PeerState, RemoteNode, Timestamp, Transaction,
+    TransactionWithStatus, TxPoolInfo, Uint64, Version,
 };
 
 use super::types;
@@ -104,8 +104,8 @@ jsonrpc!(pub struct RawHttpRpcClient {
 
     // Net
     pub fn get_banned_addresses(&mut self) -> Vec<BannedAddr>;
-    pub fn get_peers(&mut self) -> Vec<Node>;
-    pub fn local_node_info(&mut self) -> Node;
+    pub fn get_peers(&mut self) -> Vec<RemoteNode>;
+    pub fn local_node_info(&mut self) -> LocalNode;
     pub fn set_ban(
         &mut self,
         address: String,
@@ -309,13 +309,13 @@ impl HttpRpcClient {
             .map(|vec| vec.into_iter().map(Into::into).collect())
             .map_err(|err| err.to_string())
     }
-    pub fn get_peers(&mut self) -> Result<Vec<types::Node>, String> {
+    pub fn get_peers(&mut self) -> Result<Vec<types::RemoteNode>, String> {
         self.client
             .get_peers()
             .map(|vec| vec.into_iter().map(Into::into).collect())
             .map_err(|err| err.to_string())
     }
-    pub fn local_node_info(&mut self) -> Result<types::Node, String> {
+    pub fn local_node_info(&mut self) -> Result<types::LocalNode, String> {
         self.client
             .local_node_info()
             .map(Into::into)

--- a/ckb-sdk/src/rpc/mod.rs
+++ b/ckb-sdk/src/rpc/mod.rs
@@ -7,7 +7,8 @@ pub use primitive::{Capacity, EpochNumberWithFraction, Since, Timestamp};
 pub use types::{
     Alert, AlertMessage, BannedAddr, Block, BlockReward, BlockView, Byte32, CellDep, CellInput,
     CellOutput, CellOutputWithOutPoint, CellTransaction, ChainInfo, DepType, EpochView, Header,
-    HeaderView, JsonBytes, LiveCell, LockHashIndexState, Node, NodeAddress, OutPoint,
-    ProposalShortId, Script, ScriptHashType, Transaction, TransactionPoint, TransactionView,
-    TransactionWithStatus, TxPoolInfo, TxStatus, Uint128, UncleBlock, UncleBlockView,
+    HeaderView, JsonBytes, LiveCell, LocalNode, LockHashIndexState, NodeAddress, OutPoint,
+    ProposalShortId, RemoteNode, Script, ScriptHashType, Transaction, TransactionPoint,
+    TransactionView, TransactionWithStatus, TxPoolInfo, TxStatus, Uint128, UncleBlock,
+    UncleBlockView,
 };

--- a/ckb-sdk/src/rpc/types.rs
+++ b/ckb-sdk/src/rpc/types.rs
@@ -832,15 +832,30 @@ impl From<rpc_types::LockHashIndexState> for LockHashIndexState {
 //  net.rs
 // ========
 #[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
-pub struct Node {
+pub struct LocalNode {
     pub version: String,
     pub node_id: String,
     pub addresses: Vec<NodeAddress>,
-    pub is_outbound: Option<bool>,
 }
-impl From<rpc_types::Node> for Node {
-    fn from(json: rpc_types::Node) -> Node {
-        Node {
+impl From<rpc_types::LocalNode> for LocalNode {
+    fn from(json: rpc_types::LocalNode) -> LocalNode {
+        LocalNode {
+            version: json.version,
+            node_id: json.node_id,
+            addresses: json.addresses.into_iter().map(Into::into).collect(),
+        }
+    }
+}
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+pub struct RemoteNode {
+    pub version: String,
+    pub node_id: String,
+    pub addresses: Vec<NodeAddress>,
+    pub is_outbound: bool,
+}
+impl From<rpc_types::RemoteNode> for RemoteNode {
+    fn from(json: rpc_types::RemoteNode) -> RemoteNode {
+        RemoteNode {
             version: json.version,
             node_id: json.node_id,
             addresses: json.addresses.into_iter().map(Into::into).collect(),

--- a/plugin-protocol/Cargo.toml
+++ b/plugin-protocol/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2018"
 
 [dependencies]
 ckb-index = { path = "../ckb-index" }
-ckb-types = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1" }
-ckb-jsonrpc-types = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1" }
+ckb-types = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1" }
+ckb-jsonrpc-types = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1" }
 serde = { version = "1.0", features = ["rc"] }
 serde_derive = "1.0"
 serde_json = "1.0"

--- a/src/subcommands/rpc.rs
+++ b/src/subcommands/rpc.rs
@@ -4,7 +4,7 @@ use ckb_jsonrpc_types::{
 use ckb_sdk::{
     rpc::{
         BannedAddr, BlockReward, BlockView, CellOutputWithOutPoint, CellTransaction, EpochView,
-        HeaderView, LiveCell, Node, RawHttpRpcClient, TransactionWithStatus,
+        HeaderView, LiveCell, RawHttpRpcClient, RemoteNode, TransactionWithStatus,
     },
     HttpRpcClient,
 };
@@ -583,11 +583,11 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                     let resp = self
                         .raw_rpc_client
                         .get_peers()
-                        .map(RawNodes)
+                        .map(RawRemoteNodes)
                         .map_err(|err| err.to_string())?;
                     Ok(Output::new_output(resp))
                 } else {
-                    let resp = self.rpc_client.get_peers().map(Nodes)?;
+                    let resp = self.rpc_client.get_peers().map(RemoteNodes)?;
                     Ok(Output::new_output(resp))
                 }
             }
@@ -678,7 +678,7 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
 }
 
 #[derive(Serialize, Deserialize)]
-pub struct Nodes(pub Vec<Node>);
+pub struct RemoteNodes(pub Vec<RemoteNode>);
 
 #[derive(Serialize, Deserialize)]
 pub struct OptionTransactionWithStatus(pub Option<TransactionWithStatus>);
@@ -714,7 +714,7 @@ pub struct LiveCells(pub Vec<LiveCell>);
 pub struct CellTransactions(pub Vec<CellTransaction>);
 
 #[derive(Serialize, Deserialize)]
-pub struct RawNodes(pub Vec<rpc_types::Node>);
+pub struct RawRemoteNodes(pub Vec<rpc_types::RemoteNode>);
 
 #[derive(Serialize, Deserialize)]
 pub struct RawOptionTransactionWithStatus(pub Option<rpc_types::TransactionWithStatus>);

--- a/src/subcommands/tui/mod.rs
+++ b/src/subcommands/tui/mod.rs
@@ -460,18 +460,11 @@ fn render_peers<B: Backend>(state: &State, ctx: RenderContext<B>) {
         .max()
         .unwrap_or(10);
     let peers = state.peers.iter().flat_map(|node| {
-        let direction = node
-            .is_outbound
-            .map(
-                |is_outbound| {
-                    if is_outbound {
-                        "outbound"
-                    } else {
-                        "inbound"
-                    }
-                },
-            )
-            .unwrap_or("unknown");
+        let direction = if node.is_outbound {
+            "outbound"
+        } else {
+            "inbound"
+        };
         vec![Text::raw(format!(
             "{:<width$} {:8} version({})",
             node.addresses

--- a/src/subcommands/tui/state.rs
+++ b/src/subcommands/tui/state.rs
@@ -9,7 +9,7 @@ use jsonrpc_client_core::Error as RpcError;
 
 use super::util::ts_now;
 use ckb_sdk::{
-    rpc::{BlockView, ChainInfo, Node, TxPoolInfo},
+    rpc::{BlockView, ChainInfo, LocalNode, RemoteNode, TxPoolInfo},
     HttpRpcClient,
 };
 
@@ -105,9 +105,9 @@ pub struct State {
     // FIXME: should handle fork (see: ckb-monitor)
     pub(crate) blocks: BTreeMap<u64, BlockInfo>,
     pub(crate) tip_header: Option<HeaderView>,
-    pub(crate) peers: Vec<Node>,
+    pub(crate) peers: Vec<RemoteNode>,
     pub(crate) chain: Option<ChainInfo>,
-    pub(crate) local_node: Option<Node>,
+    pub(crate) local_node: Option<LocalNode>,
     pub(crate) tx_pool: Option<TxPoolInfo>,
 }
 

--- a/test/Cargo.toml
+++ b/test/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cli-test"
-version = "0.33.1"
+version = "0.34.0"
 authors = ["Linfeng Qian <thewawar@gmail.com>"]
 edition = "2018"
 
@@ -14,11 +14,11 @@ env_logger = "0.6"
 toml = "0.5.0"
 serde_yaml = "0.8.9"
 ckb-sdk = { path = "../ckb-sdk" }
-ckb-types = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1" }
-ckb-app-config = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1" }
-ckb-chain-spec = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1" }
-ckb-crypto = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1", features = ["secp"] }
-ckb-hash = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.33.0-pre1" }
+ckb-types = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1" }
+ckb-app-config = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1" }
+ckb-chain-spec = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1" }
+ckb-crypto = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1", features = ["secp"] }
+ckb-hash = { git = "https://github.com/nervosnetwork/ckb", tag = "v0.34.0-rc1" }
 regex = "1.1.6"
 
 # Prevent this from interfering with workspaces


### PR DESCRIPTION
BREAKING CHANGE: jsonrpc-types `Node` split into `LocalNode` and `RemoteNode`.