### PR TITLE
fix: Use m/44'/309'/0' as plugin keystore's root key path

### DIFF
--- a/ckb-sdk/src/wallet/mod.rs
+++ b/ckb-sdk/src/wallet/mod.rs
@@ -10,4 +10,5 @@ pub use error::Error as WalletError;
 pub use keystore::{
     zeroize_privkey, zeroize_slice, CipherParams, Crypto, DerivedKeySet, Error as KeyStoreError,
     KdfParams, Key, KeyChain, KeyStore, KeyTimeout, MasterPrivKey, ScryptParams, ScryptType,
+    CKB_ROOT_PATH,
 };

--- a/src/plugin/manager.rs
+++ b/src/plugin/manager.rs
@@ -12,7 +12,7 @@ use std::thread::{self, JoinHandle};
 use ckb_index::LiveCellInfo;
 use ckb_jsonrpc_types::{BlockNumber, HeaderView, Script};
 use ckb_sdk::{
-    wallet::{ChildNumber, DerivationPath, DerivedKeySet, MasterPrivKey},
+    wallet::{ChildNumber, DerivationPath, DerivedKeySet, MasterPrivKey, CKB_ROOT_PATH},
     HttpRpcClient,
 };
 use ckb_types::{bytes::Bytes, core::service::Request, H160, H256};
@@ -239,6 +239,9 @@ impl PluginManager {
     #[allow(unused)]
     pub fn indexer_handler(&self) -> IndexerHandler {
         IndexerHandler::new(self.service_provider.handler().clone())
+    }
+    pub fn root_key_path(&self, h160: H160) -> Result<DerivationPath, String> {
+        self.keystore_handler().root_key_path(h160)
     }
 
     pub fn active(&mut self, name: &str) -> Result<(), String> {
@@ -1248,6 +1251,14 @@ impl KeyStoreHandler {
             Some(ServiceResponse::Response(response)) => Ok(response),
             Some(_) => Err(String::from("Mismatch plugin response")),
             None => Err(String::from("Send request error")),
+        }
+    }
+
+    pub fn root_key_path(&self, h160: H160) -> Result<DerivationPath, String> {
+        if self.has_account_in_default(h160)? {
+            Ok(DerivationPath::empty())
+        } else {
+            Ok(DerivationPath::from_str(CKB_ROOT_PATH).expect("parse ckb root path"))
         }
     }
 

--- a/src/subcommands/account.rs
+++ b/src/subcommands/account.rs
@@ -400,9 +400,10 @@ impl<'a> CliSubCommand for AccountSubCommand<'a> {
             ("extended-address", Some(m)) => {
                 let lock_arg: H160 =
                     FixedHashParser::<H160>::default().from_matches(m, "lock-arg")?;
+                let root_key_path = self.plugin_mgr.root_key_path(lock_arg.clone())?;
                 let path: DerivationPath = FromStrParser::<DerivationPath>::new()
                     .from_matches_opt(m, "path", false)?
-                    .unwrap_or_else(DerivationPath::empty);
+                    .unwrap_or(root_key_path);
 
                 let password = if self.plugin_mgr.keystore_require_password() {
                     Some(read_password(false, None)?)

--- a/src/subcommands/dao/mod.rs
+++ b/src/subcommands/dao/mod.rs
@@ -12,7 +12,6 @@ use ckb_index::{with_index_db, IndexDatabase, LiveCellInfo};
 use ckb_jsonrpc_types::{self as json_types, JsonBytes};
 use ckb_sdk::{
     constants::{MIN_SECP_CELL_CAPACITY, SIGHASH_TYPE_HASH},
-    wallet::DerivationPath,
     GenesisInfo, HttpRpcClient, SignerFn,
 };
 use ckb_types::{
@@ -349,6 +348,7 @@ fn get_keystore_signer(
                 if message == &h256!("0x0") {
                     Ok(Some([0u8; 65]))
                 } else {
+                    let path = keystore.root_key_path(account.clone())?;
                     let sign_target = if keystore.has_account_in_default(account.clone())? {
                         SignTarget::AnyData(Default::default())
                     } else {
@@ -368,12 +368,12 @@ fn get_keystore_signer(
                         SignTarget::Transaction {
                             tx: tx.clone(),
                             inputs,
-                            change_path: DerivationPath::empty().to_string(),
+                            change_path: path.to_string(),
                         }
                     };
                     let data = keystore.sign(
                         account.clone(),
-                        &[],
+                        &path,
                         message.clone(),
                         sign_target,
                         password.clone(),

--- a/src/subcommands/tx.rs
+++ b/src/subcommands/tx.rs
@@ -9,7 +9,6 @@ use ckb_jsonrpc_types as json_types;
 use ckb_jsonrpc_types::JsonBytes;
 use ckb_sdk::{
     constants::{MULTISIG_TYPE_HASH, SECP_SIGNATURE_SIZE},
-    wallet::DerivationPath,
     Address, AddressPayload, CodeHashIndex, GenesisInfo, HttpRpcClient, HumanCapacity,
     MultisigConfig, NetworkType, SignerFn, TxHelper,
 };
@@ -621,6 +620,7 @@ fn get_keystore_signer(
                 if message == &h256!("0x0") {
                     Ok(Some([0u8; 65]))
                 } else {
+                    let root_key_path = keystore.root_key_path(account.clone())?;
                     let sign_target = if keystore.has_account_in_default(account.clone())? {
                         SignTarget::AnyData(Default::default())
                     } else {
@@ -640,12 +640,12 @@ fn get_keystore_signer(
                         SignTarget::Transaction {
                             tx: tx.clone(),
                             inputs,
-                            change_path: DerivationPath::empty().to_string(),
+                            change_path: root_key_path.to_string(),
                         }
                     };
                     let data = keystore.sign(
                         account.clone(),
-                        &[],
+                        &root_key_path,
                         message.clone(),
                         sign_target,
                         password.clone(),

--- a/src/subcommands/util.rs
+++ b/src/subcommands/util.rs
@@ -355,13 +355,18 @@ message = "0x"
                     };
                 let extended_address_opt: Option<Address> =
                     AddressParser::new_sighash().from_matches_opt(m, "extended-address", false)?;
+                let root_path = if let Some(ref account) = from_account_opt {
+                    self.plugin_mgr.root_key_path(account.clone())?
+                } else {
+                    DerivationPath::empty()
+                };
                 let target_path = extended_address_opt
                     .and_then(|addr| from_account_opt.clone().map(|account| (addr, account)))
                     .map(|(addr, account)| {
                         search_path(self.plugin_mgr, account, addr, password.clone())
                     })
                     .transpose()?
-                    .unwrap_or_else(DerivationPath::empty);
+                    .unwrap_or(root_path);
 
                 let (mut binary, target) = if let Some(data) = binary_opt {
                     (data.clone(), SignTarget::AnyData(JsonBytes::from_vec(data)))
@@ -423,13 +428,19 @@ message = "0x"
                     };
                 let extended_address_opt: Option<Address> =
                     AddressParser::new_sighash().from_matches_opt(m, "extended-address", false)?;
+
+                let root_path = if let Some(ref account) = from_account_opt {
+                    self.plugin_mgr.root_key_path(account.clone())?
+                } else {
+                    DerivationPath::empty()
+                };
                 let target_path = extended_address_opt
                     .and_then(|addr| from_account_opt.clone().map(|account| (addr, account)))
                     .map(|(addr, account)| {
                         search_path(self.plugin_mgr, account, addr, password.clone())
                     })
                     .transpose()?
-                    .unwrap_or_else(DerivationPath::empty);
+                    .unwrap_or(root_path);
 
                 let plugin_mgr_opt =
                     from_account_opt.map(|account| (&mut *self.plugin_mgr, account));
@@ -478,13 +489,18 @@ message = "0x"
                     } else {
                         None
                     };
+                let root_path = if let Some(ref account) = from_account_opt {
+                    self.plugin_mgr.root_key_path(account.clone())?
+                } else {
+                    DerivationPath::empty()
+                };
                 let target_path = extended_address_opt
                     .and_then(|addr| from_account_opt.clone().map(|account| (addr, account)))
                     .map(|(addr, account)| {
                         search_path(self.plugin_mgr, account, addr, password.clone())
                     })
                     .transpose()?
-                    .unwrap_or_else(DerivationPath::empty);
+                    .unwrap_or(root_path);
 
                 let pubkey = if let Some(pubkey) = pubkey_opt {
                     pubkey

--- a/src/subcommands/wallet/mod.rs
+++ b/src/subcommands/wallet/mod.rs
@@ -316,7 +316,10 @@ impl<'a> WalletSubCommand<'a> {
                     change_path_opt.expect("change path not exists"),
                 )
             } else {
-                (from_address.payload().clone(), DerivationPath::empty())
+                (
+                    from_address.payload().clone(),
+                    self.plugin_mgr.root_key_path(from_lock_arg.clone())?,
+                )
             };
 
         if let Some(from_locked_address) = from_locked_address.as_ref() {
@@ -759,12 +762,12 @@ fn get_keystore_signer(
 ) -> SignerFn {
     Box::new(
         move |lock_args: &HashSet<H160>, message: &H256, tx: &json_types::Transaction| {
-            let path: &[_] = if lock_args.contains(&account) {
-                &[]
+            let path = if lock_args.contains(&account) {
+                keystore.root_key_path(account.clone())?
             } else {
                 match lock_args.iter().find_map(|lock_arg| path_map.get(lock_arg)) {
                     None => return Ok(None),
-                    Some(path) => path.as_ref(),
+                    Some(path) => path.clone(),
                 }
             };
             if message == &h256!("0x0") {
@@ -794,7 +797,7 @@ fn get_keystore_signer(
             };
             let data = keystore.sign(
                 account.clone(),
-                path,
+                &path,
                 message.clone(),
                 sign_target,
                 password.clone(),

--- a/src/utils/other.rs
+++ b/src/utils/other.rs
@@ -86,9 +86,10 @@ pub fn get_signer(
         } else {
             None
         };
+        let path = keystore.root_key_path(lock_arg.clone())?;
         let data = keystore.sign(
             lock_arg.clone(),
-            &[],
+            &path,
             message.clone(),
             SignTarget::AnyMessage(message.clone()),
             password,


### PR DESCRIPTION
Fix #328 