### PR TITLE
fix: Improve keystore actions

### DIFF
--- a/ckb-index/src/lib.rs
+++ b/ckb-index/src/lib.rs
@@ -1,4 +1,5 @@
 mod error;
+#[allow(clippy::mutable_key_type)]
 mod index;
 mod kvdb;
 mod util;

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,9 @@ use utils::{
 
 mod interactive;
 mod plugin;
+#[allow(clippy::mutable_key_type)]
 mod subcommands;
+#[allow(clippy::mutable_key_type)]
 mod utils;
 
 fn main() -> Result<(), io::Error> {

--- a/src/plugin/builtin.rs
+++ b/src/plugin/builtin.rs
@@ -108,13 +108,13 @@ impl DefaultKeyStore {
                     change_max_len,
                     password,
                 } => {
-                    let password =
-                        password.ok_or_else(|| String::from(ERROR_KEYSTORE_REQUIRE_PASSWORD))?;
                     keystore
                         .get_ckb_root(&hash160, true)
                         .cloned()
                         .map_or_else(
                             || {
+                                let password =
+                                    password.ok_or_else(|| String::from(ERROR_KEYSTORE_REQUIRE_PASSWORD))?;
                                 keystore
                                     .ckb_root_with_password(&hash160, password.as_bytes())
                                     .map_err(|err| err.to_string())
@@ -135,13 +135,13 @@ impl DefaultKeyStore {
                     change_length,
                     password,
                 } => {
-                    let password =
-                        password.ok_or_else(|| String::from(ERROR_KEYSTORE_REQUIRE_PASSWORD))?;
                     keystore
                         .get_ckb_root(&hash160, true)
                         .cloned()
                         .map_or_else(
                             || {
+                                let password =
+                                    password.ok_or_else(|| String::from(ERROR_KEYSTORE_REQUIRE_PASSWORD))?;
                                 keystore
                                     .ckb_root_with_password(&hash160, password.as_bytes())
                                     .map_err(|err| err.to_string())

--- a/src/plugin/builtin.rs
+++ b/src/plugin/builtin.rs
@@ -107,26 +107,24 @@ impl DefaultKeyStore {
                     change_last,
                     change_max_len,
                     password,
-                } => {
-                    keystore
-                        .get_ckb_root(&hash160, true)
-                        .cloned()
-                        .map_or_else(
-                            || {
-                                let password =
-                                    password.ok_or_else(|| String::from(ERROR_KEYSTORE_REQUIRE_PASSWORD))?;
-                                keystore
-                                    .ckb_root_with_password(&hash160, password.as_bytes())
-                                    .map_err(|err| err.to_string())
-                            },
-                            Ok,
-                        )
-                        .map(|ckb_root| {
-                            ckb_root.derived_key_set(external_max_len, &change_last, change_max_len)
-                        })?
-                        .map(serilize_key_set)
-                        .map_err(|err| err.to_string())
-                }
+                } => keystore
+                    .get_ckb_root(&hash160, true)
+                    .cloned()
+                    .map_or_else(
+                        || {
+                            let password = password
+                                .ok_or_else(|| String::from(ERROR_KEYSTORE_REQUIRE_PASSWORD))?;
+                            keystore
+                                .ckb_root_with_password(&hash160, password.as_bytes())
+                                .map_err(|err| err.to_string())
+                        },
+                        Ok,
+                    )
+                    .map(|ckb_root| {
+                        ckb_root.derived_key_set(external_max_len, &change_last, change_max_len)
+                    })?
+                    .map(serilize_key_set)
+                    .map_err(|err| err.to_string()),
                 KeyStoreRequest::DerivedKeySetByIndex {
                     hash160,
                     external_start,
@@ -134,30 +132,28 @@ impl DefaultKeyStore {
                     change_start,
                     change_length,
                     password,
-                } => {
-                    keystore
-                        .get_ckb_root(&hash160, true)
-                        .cloned()
-                        .map_or_else(
-                            || {
-                                let password =
-                                    password.ok_or_else(|| String::from(ERROR_KEYSTORE_REQUIRE_PASSWORD))?;
-                                keystore
-                                    .ckb_root_with_password(&hash160, password.as_bytes())
-                                    .map_err(|err| err.to_string())
-                            },
-                            Ok,
+                } => keystore
+                    .get_ckb_root(&hash160, true)
+                    .cloned()
+                    .map_or_else(
+                        || {
+                            let password = password
+                                .ok_or_else(|| String::from(ERROR_KEYSTORE_REQUIRE_PASSWORD))?;
+                            keystore
+                                .ckb_root_with_password(&hash160, password.as_bytes())
+                                .map_err(|err| err.to_string())
+                        },
+                        Ok,
+                    )
+                    .map(|ckb_root| {
+                        ckb_root.derived_key_set_by_index(
+                            external_start,
+                            external_length,
+                            change_start,
+                            change_length,
                         )
-                        .map(|ckb_root| {
-                            ckb_root.derived_key_set_by_index(
-                                external_start,
-                                external_length,
-                                change_start,
-                                change_length,
-                            )
-                        })
-                        .map(serilize_key_set)
-                }
+                    })
+                    .map(serilize_key_set),
                 KeyStoreRequest::ListAccount => {
                     let mut accounts = keystore.get_accounts().iter().collect::<Vec<_>>();
                     accounts.sort_by(|a, b| a.1.cmp(&b.1));

--- a/src/plugin/manager.rs
+++ b/src/plugin/manager.rs
@@ -1294,14 +1294,20 @@ impl KeyStoreHandler {
             return Err("Mismatch default keystore response".to_string());
         }
         if let Some(cfg) = self.actived_plugin() {
-            if let PluginResponse::BytesVec(accounts) = self.call(request)? {
-                all_accounts.extend(
-                    accounts
-                        .into_iter()
-                        .map(|data| (data.into_bytes(), format!("[plugin]: {}", cfg.name))),
-                );
-            } else {
-                return Err("Mismatch plugin keystore response".to_string());
+            match self.call(request) {
+                Ok(PluginResponse::BytesVec(accounts)) => {
+                    all_accounts.extend(
+                        accounts
+                            .into_iter()
+                            .map(|data| (data.into_bytes(), format!("[plugin]: {}", cfg.name))),
+                    );
+                }
+                Ok(_) => {
+                    return Err("Mismatch plugin keystore response".to_string());
+                }
+                Err(err) => {
+                    log::info!("Send request to plugin({}) failed: {}", cfg.name, err);
+                }
             }
         }
         Ok(all_accounts)


### PR DESCRIPTION
* Fix `account bip44-addresses` subcommand force require password
* Handle get account list from plugin failed
* Check account existence before send keystore request