### PR TITLE
feat: Add account remove sub-command

### DIFF
--- a/ckb-sdk/src/wallet/keystore/mod.rs
+++ b/ckb-sdk/src/wallet/keystore/mod.rs
@@ -356,7 +356,7 @@ impl KeyStore {
         Ok(timed_key)
     }
 
-    fn get_filepath(&self, hash160: &H160) -> Result<PathBuf, Error> {
+    pub fn get_filepath(&self, hash160: &H160) -> Result<PathBuf, Error> {
         self.files
             .get(hash160)
             .cloned()

--- a/src/subcommands/account.rs
+++ b/src/subcommands/account.rs
@@ -170,6 +170,9 @@ impl<'a> AccountSubCommand<'a> {
                             .validator(|input| FromStrParser::<DerivationPath>::new().validate(input))
                             .about("The address path")
                     ),
+                App::new("remove")
+                    .about("Print information about how to remove an account")
+                    .arg(lock_arg().required(true)),
             ])
     }
 }
@@ -449,6 +452,19 @@ impl<'a> CliSubCommand for AccountSubCommand<'a> {
                         "mainnet": Address::new(NetworkType::Mainnet, address_payload.clone()).to_string(),
                         "testnet": Address::new(NetworkType::Testnet, address_payload).to_string(),
                     },
+                });
+                Ok(Output::new_output(resp))
+            }
+            ("remove", Some(m)) => {
+                let lock_arg: H160 =
+                    FixedHashParser::<H160>::default().from_matches(m, "lock-arg")?;
+                let filepath = self
+                    .key_store
+                    .get_filepath(&lock_arg)
+                    .map_err(|err| err.to_string())?;
+                eprintln!("WARNING: please remove it CAREFULLY! Once you remove it you may lost all assets owned by this key and it's sub-keys");
+                let resp = serde_json::json!({
+                    "filepath": filepath.to_string_lossy()
                 });
                 Ok(Output::new_output(resp))
             }


### PR DESCRIPTION
Fix issue #366 

## Demo
```
$ ./target/debug/ckb-cli account remove --lock-arg 0x1111111111111111111111111111111111111111
WARNING: please remove it CAREFULLY! Once you remove it you may lost all cells owned by this key and it's sub-keys
filepath: /home/weet/.ckb-cli/keystore/UTC--2020-99-99T03-54-24.111111111Z--1111111111111111111111111111111111111111
```