### PR TITLE
chore: change release package command

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -88,7 +88,7 @@ jobs:
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
         mkdir -p $HOME/.cargo
-        docker run --rm -i -w /ckb-cli -v $(pwd):/ckb-cli -v $HOME/.cargo:/root/.cargo $BUILDER_IMAGE scl enable llvm-toolset-7 'make prod'
+        docker run --rm -i -w /ckb-cli -v $(pwd):/ckb-cli -v $HOME/.cargo:/root/.cargo $BUILDER_IMAGE make prod
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
         gpg --import devtools/ci/signer.asc
         devtools/ci/package.sh target/release/ckb-cli

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -51,7 +51,7 @@ jobs:
         GPG_SIGNER: ${{ secrets.GPG_SIGNER }}
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
-        docker run --rm -i -w /ckb-cli -v $(pwd):/ckb-cli -e OPENSSL_STATIC=1 -e OPENSSL_LIB_DIR=/usr/local/lib -e OPENSSL_INCLUDE_DIR=/usr/local/include/openssl $BUILDER_IMAGE make prod
+        docker run --rm -i -w /ckb-cli -v $(pwd):/ckb-cli -e OPENSSL_STATIC=1 $BUILDER_IMAGE make prod
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
         gpg --import devtools/ci/signer.asc
         devtools/ci/package.sh target/release/ckb-cli
@@ -68,7 +68,7 @@ jobs:
         name: ckb-cli_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
         path: ckb-cli_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
     env:
-      BUILDER_IMAGE: nervos/ckb-docker-builder:xenial-rust-1.51.0
+      BUILDER_IMAGE: nervos/ckb-docker-builder:bionic-rust-1.51.0
       REL_PKG: x86_64-unknown-linux-gnu.tar.gz
 
   package-for-centos:

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -51,8 +51,7 @@ jobs:
         GPG_SIGNER: ${{ secrets.GPG_SIGNER }}
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
-        mkdir -p $HOME/.cargo
-        docker run --rm -i -w /ckb-cli -v $(pwd):/ckb-cli -v $HOME/.cargo:/root/.cargo -e OPENSSL_STATIC=1 -e OPENSSL_LIB_DIR=/usr/local/lib -e OPENSSL_INCLUDE_DIR=/usr/local/include/openssl $BUILDER_IMAGE make prod
+        docker run --rm -i -w /ckb-cli -v $(pwd):/ckb-cli -e OPENSSL_STATIC=1 -e OPENSSL_LIB_DIR=/usr/local/lib -e OPENSSL_INCLUDE_DIR=/usr/local/include/openssl $BUILDER_IMAGE make prod
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
         gpg --import devtools/ci/signer.asc
         devtools/ci/package.sh target/release/ckb-cli
@@ -87,8 +86,7 @@ jobs:
         GPG_SIGNER: ${{ secrets.GPG_SIGNER }}
       run: |
         export GIT_TAG_NAME=` echo ${{ github.ref }} | awk -F '/' '{print $4}' `
-        mkdir -p $HOME/.cargo
-        docker run --rm -i -w /ckb-cli -v $(pwd):/ckb-cli -v $HOME/.cargo:/root/.cargo $BUILDER_IMAGE make prod
+        docker run --rm -i -w /ckb-cli -v $(pwd):/ckb-cli $BUILDER_IMAGE make prod
         gpg --quiet --batch --yes --decrypt --passphrase="$LARGE_SECRET_PASSPHRASE" --output devtools/ci/signer.asc devtools/ci/signer.asc.gpg
         gpg --import devtools/ci/signer.asc
         devtools/ci/package.sh target/release/ckb-cli


### PR DESCRIPTION
* Do not mount .cargo
* Centos-7 builder will enable the toolset using entrypoint, so we don't need to call `scl enable` here.