### PR TITLE
fix: use from_compatible_slice to decode molecule binary data

### DIFF
--- a/src/subcommands/molecule.rs
+++ b/src/subcommands/molecule.rs
@@ -257,7 +257,7 @@ where
     T: Entity + Into<J>,
     J: serde::Serialize,
 {
-    let json: J = T::from_slice(&binary)
+    let json: J = T::from_compatible_slice(&binary)
         .map(Into::into)
         .map_err(|err| err.to_string())?;
     Ok(Output::new_output(json))

--- a/src/utils/arg_parser.rs
+++ b/src/utils/arg_parser.rs
@@ -253,6 +253,16 @@ impl std::ops::Deref for PrivkeyWrapper {
     }
 }
 
+pub struct HexFilePathParser;
+
+impl ArgParser<Vec<u8>> for HexFilePathParser {
+    fn parse(&self, input: &str) -> Result<Vec<u8>, String> {
+        let path: PathBuf = FilePathParser::new(true).parse(input)?;
+        let content = fs::read_to_string(&path).map_err(|err| err.to_string())?;
+        HexParser.parse(content.as_str())
+    }
+}
+
 pub struct PrivkeyPathParser;
 
 impl ArgParser<PrivkeyWrapper> for PrivkeyPathParser {


### PR DESCRIPTION
To support `packed::BlockV1`.