### PR TITLE
feat: add `util address-info` subcommand

### DIFF
--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -63,6 +63,7 @@ fn run_spec(spec: Box<dyn Spec>, app: &App) {
 
 fn all_specs() -> Vec<Box<dyn Spec>> {
     vec![
+        Box::new(Util),
         Box::new(Plugin),
         Box::new(RpcGetTipBlockNumber),
         Box::new(WalletTransfer),
@@ -70,6 +71,5 @@ fn all_specs() -> Vec<Box<dyn Spec>> {
         Box::new(DaoPrepareOne),
         Box::new(DaoPrepareMultiple),
         Box::new(DaoWithdrawMultiple),
-        Box::new(Util),
     ]
 }

--- a/test/src/spec/util.rs
+++ b/test/src/spec/util.rs
@@ -115,5 +115,17 @@ impl Spec for Util {
         let verify_ok = value["verify-ok"].as_bool().unwrap();
         assert_eq!(recoverable, true);
         assert_eq!(verify_ok, false);
+
+        let output = setup.cli("util address-info --address ckt1qn0wcya8hrssq4u4gyuyejh5k53rwvly54yrcwhvjhwufsw4afdjynxzuefxyp9wdghglncj77k5wt6p59sx6kukyjlwh5s467qgp8m2jyzt6r7d9jr0s9q8764qnqvze3mzrdks4p5c3j");
+        let value: serde_yaml::Value = serde_yaml::from_str(&output).unwrap();
+        assert_eq!(value["extra"]["address-type"].as_str().unwrap(), "FullType");
+        assert_eq!(value["extra"]["data-encoding"].as_str().unwrap(), "bech32");
+        assert_eq!(value["network"].as_str().unwrap(), "ckb_testnet");
+        assert_eq!(
+            value["lock_script"]["code_hash"].as_str().unwrap(),
+            "0xdeec13a7b8e100579541384ccaf4b5223733e4a5483c3aec95ddc4c1d5ea5b22"
+        );
+        assert_eq!(value["lock_script"]["hash_type"].as_str().unwrap(), "type");
+        assert_eq!(value["lock_script"]["args"].as_str().unwrap(), "0x4cc2e6526204ae6a2e8fcf12f7ad472f41a1606d5b9624beebd215d780809f6a9104bd0fcd2c86f81407f6aa098182cc7621b6d0");
     }
 }


### PR DESCRIPTION
## Example
```
$ ckb-cli util address-info --address ckt1qr0wcya8hrssq4u4gyuyejh5k53rwvly54yrcwhvjhwufsw4afdjyq2vctn9ycsy4e4zar70ztm663e0gxskqm2mjcjta67jzhtcpqyld2gsf0g0e5kgd7q5qlm25zvpstx8vgdk6q8qat7q
extra:
  address-type: Full
  data-encoding: bech32m
lock_script:
  args: 0x4cc2e6526204ae6a2e8fcf12f7ad472f41a1606d5b9624beebd215d780809f6a9104bd0fcd2c86f81407f6aa098182cc7621b6d0
  code_hash: 0xdeec13a7b8e100579541384ccaf4b5223733e4a5483c3aec95ddc4c1d5ea5b22
  hash_type: type
network: ckb_testnet
```