### PR TITLE
fix(rpc sync_state): fix ckb-cli rpc sync_state error

### DIFF
--- a/ckb-sdk/src/rpc/client.rs
+++ b/ckb-sdk/src/rpc/client.rs
@@ -2,8 +2,8 @@ use ckb_jsonrpc_types::{
     Alert, BannedAddr, Block, BlockEconomicState, BlockNumber, BlockTemplate, BlockView,
     CellWithStatus, ChainInfo, Consensus, EpochNumber, EpochView, ExtraLoggerConfig, HeaderView,
     JsonBytes, LocalNode, MainLoggerConfig, OutPoint, OutputsValidator, RawTxPool, RemoteNode,
-    Script, Timestamp, Transaction, TransactionProof, TransactionWithStatus, TxPoolInfo, Uint64,
-    Version,
+    Script, SyncState, Timestamp, Transaction, TransactionProof, TransactionWithStatus, TxPoolInfo,
+    Uint64, Version,
 };
 
 use super::primitive;
@@ -102,7 +102,7 @@ jsonrpc!(pub struct RawHttpRpcClient {
         absolute: Option<bool>,
         reason: Option<String>
     ) -> ();
-    pub fn sync_state(&mut self) -> types::PeerSyncState;
+    pub fn sync_state(&mut self) -> SyncState;
     pub fn set_network_active(&mut self, state: bool) -> ();
     pub fn add_node(&mut self, peer_id: String, address: String) -> ();
     pub fn remove_node(&mut self, peer_id: String) -> ();
@@ -316,7 +316,7 @@ impl HttpRpcClient {
             .set_ban(address, command, ban_time.map(Into::into), absolute, reason)
             .map_err(|err| err.to_string())
     }
-    pub fn sync_state(&mut self) -> Result<types::PeerSyncState, String> {
+    pub fn sync_state(&mut self) -> Result<types::SyncState, String> {
         self.client
             .sync_state()
             .map(Into::into)

--- a/ckb-sdk/src/rpc/types.rs
+++ b/ckb-sdk/src/rpc/types.rs
@@ -1035,6 +1035,32 @@ impl From<rpc_types::PeerSyncState> for PeerSyncState {
 }
 
 #[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
+pub struct SyncState {
+    pub ibd: bool,
+    pub best_known_block_number: BlockNumber,
+    pub best_known_block_timestamp: Timestamp,
+    pub orphan_blocks_count: Uint64,
+    pub inflight_blocks_count: Uint64,
+    pub fast_time: Uint64,
+    pub normal_time: Uint64,
+    pub low_time: Uint64,
+}
+impl From<rpc_types::SyncState> for SyncState {
+    fn from(json: rpc_types::SyncState) -> SyncState {
+        SyncState {
+            ibd: json.ibd,
+            best_known_block_number: json.best_known_block_number.into(),
+            best_known_block_timestamp: json.best_known_block_timestamp.into(),
+            orphan_blocks_count: json.orphan_blocks_count.value(),
+            inflight_blocks_count: json.inflight_blocks_count.value(),
+            fast_time: json.fast_time.value(),
+            normal_time: json.normal_time.value(),
+            low_time: json.low_time.value(),
+        }
+    }
+}
+
+#[derive(Clone, Default, Serialize, Deserialize, PartialEq, Eq, Hash, Debug)]
 pub struct NodeAddress {
     pub address: String,
     pub score: Uint64,


### PR DESCRIPTION
when `ckb-cli rpc sync_state`, the error message is: `missing field "unknown_header_list_size"`

## Cause
sync_state() in client.rs wrongly returns `PeerSyncState` instead of `SyncState`

## Fix
- fix sync_state() in client.rs,  return SyncState
- add corresponding SyncState in types.rs

## Verify
$ ./ckb-cli rpc sync_state
best_known_block_number: 7211562
best_known_block_timestamp: "1653289577050 (2022-05-23 15:06:17.050 +08:00)"
fast_time: 595
ibd: false
inflight_blocks_count: 0
low_time: 1319
normal_time: 1136
orphan_blocks_count: 0

$ ./ckb-cli rpc sync_state --raw-data
best_known_block_number: 0x6e0a2c
best_known_block_timestamp: 0x180efbd198f
fast_time: 0x253
ibd: false
inflight_blocks_count: 0x0
low_time: 0x527
normal_time: 0x470
orphan_blocks_count: 0x0