### PR TITLE
fix: Fix 2 problems of wallet subcommands

### DIFF
--- a/src/subcommands/api_server.rs
+++ b/src/subcommands/api_server.rs
@@ -382,6 +382,7 @@ pub struct HttpTransferArgs {
     pub to_address: String,
     pub from_locked_address: Option<String>,
     pub to_data: Option<Bytes>,
+    pub force_small_change_as_fee: Option<String>,
 }
 
 impl HttpTransferArgs {
@@ -397,7 +398,7 @@ impl HttpTransferArgs {
             derive_change_address: None,
             capacity,
             fee_rate,
-            force_small_change_as_fee: None,
+            force_small_change_as_fee: self.force_small_change_as_fee,
             to_address: self.to_address,
             to_data: self.to_data,
             is_type_id: false,

--- a/src/subcommands/api_server.rs
+++ b/src/subcommands/api_server.rs
@@ -397,6 +397,7 @@ impl HttpTransferArgs {
             derive_change_address: None,
             capacity,
             fee_rate,
+            force_small_change_as_fee: None,
             to_address: self.to_address,
             to_data: self.to_data,
             is_type_id: false,

--- a/src/subcommands/dao/command.rs
+++ b/src/subcommands/dao/command.rs
@@ -109,6 +109,7 @@ pub struct TransactArgs {
     pub(crate) privkey: Option<PrivkeyWrapper>,
     pub(crate) address: Address,
     pub(crate) fee_rate: u64,
+    pub(crate) force_small_change_as_fee: Option<u64>,
 }
 
 impl TransactArgs {
@@ -142,10 +143,14 @@ impl TransactArgs {
             Address::new(network_type, payload, false)
         };
         let fee_rate: u64 = FromStrParser::<u64>::default().from_matches(m, "fee-rate")?;
+
+        let force_small_change_as_fee =
+            FromStrParser::<u64>::default().from_matches_opt(m, "max-tx-fee")?;
         Ok(Self {
             privkey,
             address,
             fee_rate,
+            force_small_change_as_fee,
         })
     }
 
@@ -154,6 +159,7 @@ impl TransactArgs {
             arg::privkey_path().required_unless(arg::from_account().get_name()),
             arg::from_account().required_unless(arg::privkey_path().get_name()),
             arg::fee_rate(),
+            arg::max_tx_fee(),
         ]
     }
 }

--- a/src/subcommands/dao/command.rs
+++ b/src/subcommands/dao/command.rs
@@ -9,7 +9,7 @@ use crate::utils::{
     other::{get_address, get_network_type},
 };
 use ckb_crypto::secp::SECP256K1;
-use ckb_sdk::{Address, AddressPayload, NetworkType};
+use ckb_sdk::{Address, AddressPayload, HumanCapacity, NetworkType};
 use ckb_types::{packed::Script, H160};
 use clap::{App, Arg, ArgMatches};
 use std::collections::HashSet;
@@ -145,7 +145,7 @@ impl TransactArgs {
         let fee_rate: u64 = FromStrParser::<u64>::default().from_matches(m, "fee-rate")?;
 
         let force_small_change_as_fee =
-            FromStrParser::<u64>::default().from_matches_opt(m, "max-tx-fee")?;
+            FromStrParser::<HumanCapacity>::default().from_matches_opt(m, "max-tx-fee")?;
         Ok(Self {
             privkey,
             address,

--- a/src/subcommands/dao/mod.rs
+++ b/src/subcommands/dao/mod.rs
@@ -85,7 +85,7 @@ impl<'a> DAOSubCommand<'a> {
                     .lock(Some(Bytes::from(vec![0u8; 65])).pack())
                     .build(),
             )]),
-            force_small_change_as_fee: None,
+            force_small_change_as_fee: args.force_small_change_as_fee,
         };
 
         let signer: Box<dyn Signer> = if let Some(privkey) = args.privkey.as_ref() {

--- a/src/subcommands/dao/mod.rs
+++ b/src/subcommands/dao/mod.rs
@@ -31,11 +31,11 @@ use ckb_types::{
 use plugin_protocol::LiveCellInfo;
 
 use self::command::TransactArgs;
-use crate::plugin::PluginManager;
 use crate::utils::genesis_info::GenesisInfo;
 use crate::utils::other::{read_password, to_live_cell_info};
 use crate::utils::rpc::HttpRpcClient;
 use crate::utils::signer::KeyStoreHandlerSigner;
+use crate::{plugin::PluginManager, subcommands::util::map_tx_builder_error_2_str};
 
 mod command;
 mod util;
@@ -123,7 +123,9 @@ impl<'a> DAOSubCommand<'a> {
                 &balancer,
                 &unlockers,
             )
-            .map_err(|err| err.to_string())?;
+            .map_err(|err| {
+                map_tx_builder_error_2_str(balancer.force_small_change_as_fee.is_none(), err)
+            })?;
         assert!(still_locked_groups.is_empty());
         Ok(tx)
     }

--- a/src/subcommands/dao/mod.rs
+++ b/src/subcommands/dao/mod.rs
@@ -31,11 +31,15 @@ use ckb_types::{
 use plugin_protocol::LiveCellInfo;
 
 use self::command::TransactArgs;
-use crate::utils::genesis_info::GenesisInfo;
-use crate::utils::other::{read_password, to_live_cell_info};
-use crate::utils::rpc::HttpRpcClient;
-use crate::utils::signer::KeyStoreHandlerSigner;
-use crate::{plugin::PluginManager, subcommands::util::map_tx_builder_error_2_str};
+use crate::{
+    plugin::PluginManager,
+    utils::{
+        genesis_info::GenesisInfo,
+        other::{map_tx_builder_error_2_str, read_password, to_live_cell_info},
+        rpc::HttpRpcClient,
+        signer::KeyStoreHandlerSigner,
+    },
+};
 
 mod command;
 mod util;

--- a/src/subcommands/sudt.rs
+++ b/src/subcommands/sudt.rs
@@ -33,20 +33,22 @@ use ckb_types::{
     H160, H256,
 };
 
-use crate::subcommands::{CliSubCommand, Output};
-use crate::utils::{
-    arg,
-    arg_parser::{
-        AddressParser, ArgParser, CellDepsParser, FromStrParser, PrivkeyPathParser, PrivkeyWrapper,
-        UdtTargetParser,
+use crate::{
+    plugin::PluginManager,
+    subcommands::{CliSubCommand, Output},
+    utils::{
+        arg,
+        arg_parser::{
+            AddressParser, ArgParser, CellDepsParser, FromStrParser, PrivkeyPathParser,
+            PrivkeyWrapper, UdtTargetParser,
+        },
+        cell_dep::{CellDepName, CellDeps},
+        genesis_info::GenesisInfo,
+        other::{get_network_type, map_tx_builder_error_2_str, read_password},
+        rpc::HttpRpcClient,
+        signer::{CommonSigner, KeyStoreHandlerSigner, PrivkeySigner},
     },
-    cell_dep::{CellDepName, CellDeps},
-    genesis_info::GenesisInfo,
-    other::{get_network_type, read_password},
-    rpc::HttpRpcClient,
-    signer::{CommonSigner, KeyStoreHandlerSigner, PrivkeySigner},
 };
-use crate::{plugin::PluginManager, subcommands::util::map_tx_builder_error_2_str};
 
 pub struct SudtSubCommand<'a> {
     plugin_mgr: &'a mut PluginManager,

--- a/src/subcommands/sudt.rs
+++ b/src/subcommands/sudt.rs
@@ -57,6 +57,14 @@ pub struct SudtSubCommand<'a> {
     tx_dep_provider: DefaultTransactionDependencyProvider,
 }
 
+struct SudtCommonArgs {
+    privkeys: Vec<PrivkeyWrapper>,
+    cell_deps: CellDeps,
+    fee_rate: u64,
+    force_small_change_as_fee: Option<u64>,
+    debug: bool,
+}
+
 impl<'a> SudtSubCommand<'a> {
     pub fn new(
         rpc_client: &'a mut HttpRpcClient,
@@ -109,7 +117,8 @@ impl<'a> SudtSubCommand<'a> {
                             .about("Treat all addresses in <udt-to> as cheque receiver (sighash address, and the cheque sender is the <owner>), otherwise the address will be used as the lock script of the SUDT cell")
                     )
                     .arg(arg::privkey_path().multiple(true))
-                    .arg(arg::fee_rate()),
+                    .arg(arg::fee_rate())
+                    .arg(arg::max_tx_fee()),
                 App::new("transfer")
                     .about("Transfer SUDT to multiple addresses (all target addresses must have same lock script id)")
                     .arg(arg_owner())
@@ -127,7 +136,8 @@ impl<'a> SudtSubCommand<'a> {
                     )
                     .arg(arg_capacity_provider())
                     .arg(arg::privkey_path().multiple(true))
-                    .arg(arg::fee_rate()),
+                    .arg(arg::fee_rate())
+                    .arg(arg::max_tx_fee()),
                 App::new("get-amount")
                     .about("Get SUDT total amount of an address")
                     .arg(arg_owner())
@@ -154,7 +164,8 @@ impl<'a> SudtSubCommand<'a> {
                     )
                     .arg(arg_cell_deps())
                     .arg(arg::privkey_path().multiple(true))
-                    .arg(arg::fee_rate()),
+                    .arg(arg::fee_rate())
+                    .arg(arg::max_tx_fee()),
                 App::new("cheque-claim")
                     .about("Claim all cheque cells identified by given lock script and type script")
                     .arg(arg_owner())
@@ -167,7 +178,8 @@ impl<'a> SudtSubCommand<'a> {
                     .arg(arg_capacity_provider())
                     .arg(arg_cell_deps())
                     .arg(arg::privkey_path().multiple(true))
-                    .arg(arg::fee_rate()),
+                    .arg(arg::fee_rate())
+                    .arg(arg::max_tx_fee()),
                 App::new("cheque-withdraw")
                     .about("Withdraw all cheque cells identified by given lock script and type script")
                     .arg(arg_owner())
@@ -177,7 +189,8 @@ impl<'a> SudtSubCommand<'a> {
                     .arg(arg_to_acp_address().about("Withdraw to anyone-can-pay address, will use <sender> to build the anyone-can-pay address, the cell must be already exists"))
                     .arg(arg_cell_deps())
                     .arg(arg::privkey_path().multiple(true))
-                    .arg(arg::fee_rate()),
+                    .arg(arg::fee_rate())
+                    .arg(arg::max_tx_fee()),
                 // TODO: move this subcommand to `util`
                 App::new("build-acp-address")
                     .about("Build an anyone-can-pay address by sighash address and anyone-can-pay script id.")
@@ -201,11 +214,8 @@ impl<'a> SudtSubCommand<'a> {
     fn issue(
         &mut self,
         args: IssueArgs,
-        privkeys: Vec<PrivkeyWrapper>,
-        cell_deps: CellDeps,
-        fee_rate: u64,
+        common_args: SudtCommonArgs,
         network: NetworkType,
-        debug: bool,
     ) -> Result<Output, String> {
         let IssueArgs {
             owner,
@@ -213,6 +223,13 @@ impl<'a> SudtSubCommand<'a> {
             to_cheque_address,
             to_acp_address,
         } = args;
+        let SudtCommonArgs {
+            privkeys,
+            cell_deps,
+            fee_rate,
+            force_small_change_as_fee,
+            debug,
+        } = common_args;
         let udt_script_id = get_script_id(&cell_deps, CellDepName::Sudt)?;
         let udt_type = UdtType::Sudt;
         let acp_script_id = if to_acp_address {
@@ -291,6 +308,7 @@ impl<'a> SudtSubCommand<'a> {
             acp_script_id,
             None,
             fee_rate,
+            force_small_change_as_fee,
         )?;
 
         let outputs_validator = Some(json_types::OutputsValidator::Passthrough);
@@ -320,11 +338,8 @@ impl<'a> SudtSubCommand<'a> {
     fn transfer(
         &mut self,
         args: TransferArgs,
-        privkeys: Vec<PrivkeyWrapper>,
-        cell_deps: CellDeps,
-        fee_rate: u64,
+        common_args: SudtCommonArgs,
         network: NetworkType,
-        debug: bool,
     ) -> Result<Output, String> {
         let TransferArgs {
             owner,
@@ -334,6 +349,13 @@ impl<'a> SudtSubCommand<'a> {
             to_acp_address,
             capacity_provider,
         } = args;
+        let SudtCommonArgs {
+            privkeys,
+            cell_deps,
+            fee_rate,
+            force_small_change_as_fee,
+            debug,
+        } = common_args;
         let udt_script_id = get_script_id(&cell_deps, CellDepName::Sudt)?;
         let udt_type = UdtType::Sudt;
         let acp_script_id = get_script_id(&cell_deps, CellDepName::Acp)?;
@@ -429,6 +451,7 @@ impl<'a> SudtSubCommand<'a> {
             Some(acp_script_id),
             None,
             fee_rate,
+            force_small_change_as_fee,
         )?;
 
         let outputs_validator = Some(json_types::OutputsValidator::Passthrough);
@@ -504,17 +527,21 @@ impl<'a> SudtSubCommand<'a> {
     fn new_empty_acp(
         &mut self,
         args: NewAcpArgs,
-        privkeys: Vec<PrivkeyWrapper>,
-        cell_deps: CellDeps,
-        fee_rate: u64,
+        common_args: SudtCommonArgs,
         network: NetworkType,
-        debug: bool,
     ) -> Result<Output, String> {
         let NewAcpArgs {
             owner,
             to,
             capacity_provider,
         } = args;
+        let SudtCommonArgs {
+            privkeys,
+            cell_deps,
+            fee_rate,
+            force_small_change_as_fee,
+            debug,
+        } = common_args;
         let udt_script_id = get_script_id(&cell_deps, CellDepName::Sudt)?;
         let udt_type = UdtType::Sudt;
         let acp_script_id = get_script_id(&cell_deps, CellDepName::Acp)?;
@@ -568,6 +595,7 @@ impl<'a> SudtSubCommand<'a> {
             None,
             None,
             fee_rate,
+            force_small_change_as_fee,
         )?;
         let outputs_validator = Some(json_types::OutputsValidator::Passthrough);
         let tx_hash = self
@@ -596,10 +624,7 @@ impl<'a> SudtSubCommand<'a> {
     fn cheque_claim(
         &mut self,
         args: ClaimArgs,
-        privkeys: Vec<PrivkeyWrapper>,
-        cell_deps: CellDeps,
-        fee_rate: u64,
-        debug: bool,
+        common_args: SudtCommonArgs,
     ) -> Result<Output, String> {
         let ClaimArgs {
             owner,
@@ -607,6 +632,13 @@ impl<'a> SudtSubCommand<'a> {
             receiver,
             capacity_provider,
         } = args;
+        let SudtCommonArgs {
+            privkeys,
+            cell_deps,
+            fee_rate,
+            force_small_change_as_fee,
+            debug,
+        } = common_args;
         let udt_script_id = get_script_id(&cell_deps, CellDepName::Sudt)?;
         let cheque_script_id = get_script_id(&cell_deps, CellDepName::Cheque)?;
         let acp_script_id = get_script_id(&cell_deps, CellDepName::Acp)?;
@@ -698,6 +730,7 @@ impl<'a> SudtSubCommand<'a> {
             Some(acp_script_id),
             Some((cheque_script_id, ChequeAction::Claim)),
             fee_rate,
+            force_small_change_as_fee,
         )?;
 
         let outputs_validator = Some(json_types::OutputsValidator::Passthrough);
@@ -721,10 +754,7 @@ impl<'a> SudtSubCommand<'a> {
     fn cheque_withdraw(
         &mut self,
         args: WithdrawArgs,
-        privkeys: Vec<PrivkeyWrapper>,
-        cell_deps: CellDeps,
-        fee_rate: u64,
-        debug: bool,
+        common_args: SudtCommonArgs,
     ) -> Result<Output, String> {
         let WithdrawArgs {
             owner,
@@ -733,6 +763,13 @@ impl<'a> SudtSubCommand<'a> {
             capacity_provider,
             to_acp_address,
         } = args;
+        let SudtCommonArgs {
+            privkeys,
+            cell_deps,
+            fee_rate,
+            force_small_change_as_fee,
+            debug,
+        } = common_args;
         let udt_script_id = get_script_id(&cell_deps, CellDepName::Sudt)?;
         let cheque_script_id = get_script_id(&cell_deps, CellDepName::Cheque)?;
         let acp_script_id = if to_acp_address {
@@ -808,6 +845,7 @@ impl<'a> SudtSubCommand<'a> {
             acp_script_id,
             Some((cheque_script_id, ChequeAction::Withdraw)),
             fee_rate,
+            force_small_change_as_fee,
         )?;
 
         let outputs_validator = Some(json_types::OutputsValidator::Passthrough);
@@ -846,6 +884,8 @@ impl<'a> CliSubCommand for SudtSubCommand<'a> {
                     PrivkeyPathParser.from_matches_vec(m, "privkey-path")?;
                 let cell_deps: CellDeps = CellDepsParser.from_matches(m, "cell-deps")?;
                 let fee_rate: u64 = FromStrParser::<u64>::default().from_matches(m, "fee-rate")?;
+                let force_small_change_as_fee =
+                    FromStrParser::<u64>::default().from_matches_opt(m, "max-tx-fee")?;
                 let to_cheque_address = m.is_present("to-cheque-address");
                 let to_acp_address = m.is_present("to-acp-address");
 
@@ -864,11 +904,14 @@ impl<'a> CliSubCommand for SudtSubCommand<'a> {
                         to_cheque_address,
                         to_acp_address,
                     },
-                    privkeys,
-                    cell_deps,
-                    fee_rate,
+                    SudtCommonArgs {
+                        privkeys,
+                        cell_deps,
+                        fee_rate,
+                        force_small_change_as_fee,
+                        debug,
+                    },
                     network,
-                    debug,
                 )
             }
             ("transfer", Some(m)) => {
@@ -892,6 +935,8 @@ impl<'a> CliSubCommand for SudtSubCommand<'a> {
                 let to_cheque_address = m.is_present("to-cheque-address");
                 let to_acp_address = m.is_present("to-acp-address");
                 let fee_rate: u64 = FromStrParser::<u64>::default().from_matches(m, "fee-rate")?;
+                let force_small_change_as_fee =
+                    FromStrParser::<u64>::default().from_matches_opt(m, "max-tx-fee")?;
 
                 check_udt_args(
                     &udt_to_vec,
@@ -910,11 +955,14 @@ impl<'a> CliSubCommand for SudtSubCommand<'a> {
                         to_acp_address,
                         capacity_provider,
                     },
-                    privkeys,
-                    cell_deps,
-                    fee_rate,
+                    SudtCommonArgs {
+                        privkeys,
+                        cell_deps,
+                        fee_rate,
+                        force_small_change_as_fee,
+                        debug,
+                    },
                     network,
-                    debug,
                 )
             }
             ("get-amount", Some(m)) => {
@@ -941,17 +989,22 @@ impl<'a> CliSubCommand for SudtSubCommand<'a> {
                     PrivkeyPathParser.from_matches_vec(m, "privkey-path")?;
                 let cell_deps: CellDeps = CellDepsParser.from_matches(m, "cell-deps")?;
                 let fee_rate: u64 = FromStrParser::<u64>::default().from_matches(m, "fee-rate")?;
+                let force_small_change_as_fee =
+                    FromStrParser::<u64>::default().from_matches_opt(m, "max-tx-fee")?;
                 self.new_empty_acp(
                     NewAcpArgs {
                         owner,
                         to,
                         capacity_provider,
                     },
-                    privkeys,
-                    cell_deps,
-                    fee_rate,
+                    SudtCommonArgs {
+                        privkeys,
+                        cell_deps,
+                        fee_rate,
+                        force_small_change_as_fee,
+                        debug,
+                    },
                     network,
-                    debug,
                 )
             }
             ("cheque-claim", Some(m)) => {
@@ -971,6 +1024,8 @@ impl<'a> CliSubCommand for SudtSubCommand<'a> {
                     PrivkeyPathParser.from_matches_vec(m, "privkey-path")?;
                 let cell_deps: CellDeps = CellDepsParser.from_matches(m, "cell-deps")?;
                 let fee_rate: u64 = FromStrParser::<u64>::default().from_matches(m, "fee-rate")?;
+                let force_small_change_as_fee =
+                    FromStrParser::<u64>::default().from_matches_opt(m, "max-tx-fee")?;
 
                 if capacity_provider.as_ref() == Some(&sender) {
                     return Err("<capacity-provider> can't be the same with <sender>".to_string());
@@ -982,10 +1037,13 @@ impl<'a> CliSubCommand for SudtSubCommand<'a> {
                         receiver,
                         capacity_provider,
                     },
-                    privkeys,
-                    cell_deps,
-                    fee_rate,
-                    debug,
+                    SudtCommonArgs {
+                        privkeys,
+                        cell_deps,
+                        fee_rate,
+                        force_small_change_as_fee,
+                        debug,
+                    },
                 )
             }
             ("cheque-withdraw", Some(m)) => {
@@ -1006,6 +1064,8 @@ impl<'a> CliSubCommand for SudtSubCommand<'a> {
                     PrivkeyPathParser.from_matches_vec(m, "privkey-path")?;
                 let cell_deps: CellDeps = CellDepsParser.from_matches(m, "cell-deps")?;
                 let fee_rate: u64 = FromStrParser::<u64>::default().from_matches(m, "fee-rate")?;
+                let force_small_change_as_fee =
+                    FromStrParser::<u64>::default().from_matches_opt(m, "max-tx-fee")?;
                 self.cheque_withdraw(
                     WithdrawArgs {
                         owner,
@@ -1014,10 +1074,13 @@ impl<'a> CliSubCommand for SudtSubCommand<'a> {
                         capacity_provider,
                         to_acp_address,
                     },
-                    privkeys,
-                    cell_deps,
-                    fee_rate,
-                    debug,
+                    SudtCommonArgs {
+                        privkeys,
+                        cell_deps,
+                        fee_rate,
+                        force_small_change_as_fee,
+                        debug,
+                    },
                 )
             }
             ("build-acp-address", Some(m)) => {
@@ -1197,6 +1260,7 @@ impl<'a> UdtTxBuilder<'a> {
         acp_script_id: Option<ScriptId>,
         cheque_script_id: Option<(ScriptId, ChequeAction)>,
         fee_rate: u64,
+        force_small_change_as_fee: Option<u64>,
     ) -> Result<TransactionView, String> {
         let mut passwords: HashMap<H160, String> = HashMap::with_capacity(accounts.len());
         let sighash_script_id = ScriptId::new_type(SIGHASH_TYPE_HASH.clone());
@@ -1269,7 +1333,7 @@ impl<'a> UdtTxBuilder<'a> {
                     .lock(Some(Bytes::from(vec![0u8; 65])).pack())
                     .build(),
             )]),
-            force_small_change_as_fee: None,
+            force_small_change_as_fee,
         };
 
         cell_deps.apply_to_resolver(self.cell_dep_resolver)?;

--- a/src/subcommands/sudt.rs
+++ b/src/subcommands/sudt.rs
@@ -23,7 +23,7 @@ use ckb_sdk::{
         AcpScriptSigner, AcpUnlocker, ChequeAction, ChequeScriptSigner, ChequeUnlocker,
         ScriptUnlocker, SecpSighashScriptSigner, SecpSighashUnlocker,
     },
-    Address, AddressPayload, NetworkType,
+    Address, AddressPayload, HumanCapacity, NetworkType,
 };
 use ckb_types::{
     bytes::Bytes,
@@ -885,7 +885,7 @@ impl<'a> CliSubCommand for SudtSubCommand<'a> {
                 let cell_deps: CellDeps = CellDepsParser.from_matches(m, "cell-deps")?;
                 let fee_rate: u64 = FromStrParser::<u64>::default().from_matches(m, "fee-rate")?;
                 let force_small_change_as_fee =
-                    FromStrParser::<u64>::default().from_matches_opt(m, "max-tx-fee")?;
+                    FromStrParser::<HumanCapacity>::default().from_matches_opt(m, "max-tx-fee")?;
                 let to_cheque_address = m.is_present("to-cheque-address");
                 let to_acp_address = m.is_present("to-acp-address");
 
@@ -936,7 +936,7 @@ impl<'a> CliSubCommand for SudtSubCommand<'a> {
                 let to_acp_address = m.is_present("to-acp-address");
                 let fee_rate: u64 = FromStrParser::<u64>::default().from_matches(m, "fee-rate")?;
                 let force_small_change_as_fee =
-                    FromStrParser::<u64>::default().from_matches_opt(m, "max-tx-fee")?;
+                    FromStrParser::<HumanCapacity>::default().from_matches_opt(m, "max-tx-fee")?;
 
                 check_udt_args(
                     &udt_to_vec,
@@ -990,7 +990,7 @@ impl<'a> CliSubCommand for SudtSubCommand<'a> {
                 let cell_deps: CellDeps = CellDepsParser.from_matches(m, "cell-deps")?;
                 let fee_rate: u64 = FromStrParser::<u64>::default().from_matches(m, "fee-rate")?;
                 let force_small_change_as_fee =
-                    FromStrParser::<u64>::default().from_matches_opt(m, "max-tx-fee")?;
+                    FromStrParser::<HumanCapacity>::default().from_matches_opt(m, "max-tx-fee")?;
                 self.new_empty_acp(
                     NewAcpArgs {
                         owner,
@@ -1025,7 +1025,7 @@ impl<'a> CliSubCommand for SudtSubCommand<'a> {
                 let cell_deps: CellDeps = CellDepsParser.from_matches(m, "cell-deps")?;
                 let fee_rate: u64 = FromStrParser::<u64>::default().from_matches(m, "fee-rate")?;
                 let force_small_change_as_fee =
-                    FromStrParser::<u64>::default().from_matches_opt(m, "max-tx-fee")?;
+                    FromStrParser::<HumanCapacity>::default().from_matches_opt(m, "max-tx-fee")?;
 
                 if capacity_provider.as_ref() == Some(&sender) {
                     return Err("<capacity-provider> can't be the same with <sender>".to_string());
@@ -1065,7 +1065,7 @@ impl<'a> CliSubCommand for SudtSubCommand<'a> {
                 let cell_deps: CellDeps = CellDepsParser.from_matches(m, "cell-deps")?;
                 let fee_rate: u64 = FromStrParser::<u64>::default().from_matches(m, "fee-rate")?;
                 let force_small_change_as_fee =
-                    FromStrParser::<u64>::default().from_matches_opt(m, "max-tx-fee")?;
+                    FromStrParser::<HumanCapacity>::default().from_matches_opt(m, "max-tx-fee")?;
                 self.cheque_withdraw(
                     WithdrawArgs {
                         owner,

--- a/src/subcommands/sudt.rs
+++ b/src/subcommands/sudt.rs
@@ -33,7 +33,6 @@ use ckb_types::{
     H160, H256,
 };
 
-use crate::plugin::PluginManager;
 use crate::subcommands::{CliSubCommand, Output};
 use crate::utils::{
     arg,
@@ -47,6 +46,7 @@ use crate::utils::{
     rpc::HttpRpcClient,
     signer::{CommonSigner, KeyStoreHandlerSigner, PrivkeySigner},
 };
+use crate::{plugin::PluginManager, subcommands::util::map_tx_builder_error_2_str};
 
 pub struct SudtSubCommand<'a> {
     plugin_mgr: &'a mut PluginManager,
@@ -1348,7 +1348,9 @@ impl<'a> UdtTxBuilder<'a> {
                 &balancer,
                 &unlockers,
             )
-            .map_err(|err| err.to_string())?;
+            .map_err(|err| {
+                map_tx_builder_error_2_str(balancer.force_small_change_as_fee.is_none(), err)
+            })?;
 
         assert!(
             still_locked_groups.is_empty(),

--- a/src/subcommands/util.rs
+++ b/src/subcommands/util.rs
@@ -15,7 +15,6 @@ use ckb_hash::blake2b_256;
 use ckb_jsonrpc_types::{self as json_types, JsonBytes};
 use ckb_sdk::{
     constants::{DAO_TYPE_HASH, MULTISIG_TYPE_HASH, SIGHASH_TYPE_HASH, TYPE_ID_CODE_HASH},
-    tx_builder::{BalanceTxCapacityError, TxBuilderError},
     util::serialize_signature,
     Address, AddressPayload, NetworkType, OldAddress,
 };
@@ -932,19 +931,6 @@ fn to_timestamp(input: &str) -> Result<u64, String> {
     let date = NaiveDateTime::parse_from_str(&format!("{} 00:00:00", date), "%Y-%m-%d  %H:%M:%S")
         .map_err(|err| format!("{:?}", err))?;
     Ok(date.timestamp_millis() as u64)
-}
-
-pub(crate) fn map_tx_builder_error_2_str(no_max_tx_fee: bool, err: TxBuilderError) -> String {
-    if no_max_tx_fee {
-        if let TxBuilderError::BalanceCapacity(BalanceTxCapacityError::CapacityNotEnough(ref msg)) =
-            err
-        {
-            if msg.contains("can not create change cell") {
-                return format!("{}, {}.", err, "try to calculate capacity again or try parameter `--max-tx-fee` to make small left capacity as transaction fee");
-            }
-        }
-    }
-    err.to_string()
 }
 
 #[cfg(test)]

--- a/src/subcommands/util.rs
+++ b/src/subcommands/util.rs
@@ -15,6 +15,7 @@ use ckb_hash::blake2b_256;
 use ckb_jsonrpc_types::{self as json_types, JsonBytes};
 use ckb_sdk::{
     constants::{DAO_TYPE_HASH, MULTISIG_TYPE_HASH, SIGHASH_TYPE_HASH, TYPE_ID_CODE_HASH},
+    tx_builder::{BalanceTxCapacityError, TxBuilderError},
     util::serialize_signature,
     Address, AddressPayload, NetworkType, OldAddress,
 };
@@ -931,6 +932,19 @@ fn to_timestamp(input: &str) -> Result<u64, String> {
     let date = NaiveDateTime::parse_from_str(&format!("{} 00:00:00", date), "%Y-%m-%d  %H:%M:%S")
         .map_err(|err| format!("{:?}", err))?;
     Ok(date.timestamp_millis() as u64)
+}
+
+pub(crate) fn map_tx_builder_error_2_str(no_max_tx_fee: bool, err: TxBuilderError) -> String {
+    if no_max_tx_fee {
+        if let TxBuilderError::BalanceCapacity(BalanceTxCapacityError::CapacityNotEnough(ref msg)) =
+            err
+        {
+            if msg.contains("can not create change cell") {
+                return format!("{}, {}.", err, "try to calculate capacity again or try parameter `--max-tx-fee` to make small left capacity as transaction fee");
+            }
+        }
+    }
+    err.to_string()
 }
 
 #[cfg(test)]

--- a/src/subcommands/wallet.rs
+++ b/src/subcommands/wallet.rs
@@ -118,7 +118,7 @@ impl<'a> WalletSubCommand<'a> {
                     .arg(arg::lock_arg())
                     .arg(arg::derive_receiving_address_length())
                     .arg(arg::derive_change_address_length())
-                    .arg(arg::derived().conflicts_with(arg::lock_hash().get_name())),
+                    .arg(arg::derived()),
                 App::new("get-live-cells")
                     .about("Get live cells by address")
                     .arg(arg::address())

--- a/src/subcommands/wallet.rs
+++ b/src/subcommands/wallet.rs
@@ -36,6 +36,7 @@ use ckb_types::{
 use plugin_protocol::LiveCellInfo;
 
 use super::{CliSubCommand, Output};
+use crate::plugin::PluginManager;
 use crate::utils::{
     arg,
     arg_parser::{
@@ -45,12 +46,11 @@ use crate::utils::{
     genesis_info::GenesisInfo,
     other::{
         check_capacity, get_address, get_arg_value, get_genesis_info, get_network_type,
-        get_to_data, read_password, to_live_cell_info,
+        get_to_data, map_tx_builder_error_2_str, read_password, to_live_cell_info,
     },
     rpc::HttpRpcClient,
     signer::KeyStoreHandlerSigner,
 };
-use crate::{plugin::PluginManager, subcommands::util::map_tx_builder_error_2_str};
 
 // Max derived change address to search
 const DERIVE_CHANGE_ADDRESS_MAX_LEN: u32 = 10000;

--- a/src/subcommands/wallet.rs
+++ b/src/subcommands/wallet.rs
@@ -97,7 +97,7 @@ impl<'a> WalletSubCommand<'a> {
                     .arg(arg::to_data_path())
                     .arg(arg::capacity().required(true))
                     .arg(arg::fee_rate())
-                    .arg(arg::force_small_change_as_fee())
+                    .arg(arg::max_tx_fee())
                     .arg(arg::derive_receiving_address_length())
                     .arg(
                         arg::derive_change_address().conflicts_with(arg::privkey_path().get_name()),
@@ -530,9 +530,7 @@ impl<'a> CliSubCommand for WalletSubCommand<'a> {
                     password: None,
                     capacity: get_arg_value(m, "capacity")?,
                     fee_rate: get_arg_value(m, "fee-rate")?,
-                    force_small_change_as_fee: m
-                        .value_of("force-small-change-as-fee")
-                        .map(|s| s.to_string()),
+                    force_small_change_as_fee: m.value_of("max-tx-fee").map(|s| s.to_string()),
                     derive_receiving_address_length: Some(get_arg_value(
                         m,
                         "derive-receiving-address-length",

--- a/src/subcommands/wallet.rs
+++ b/src/subcommands/wallet.rs
@@ -36,7 +36,6 @@ use ckb_types::{
 use plugin_protocol::LiveCellInfo;
 
 use super::{CliSubCommand, Output};
-use crate::plugin::PluginManager;
 use crate::utils::{
     arg,
     arg_parser::{
@@ -51,6 +50,7 @@ use crate::utils::{
     rpc::HttpRpcClient,
     signer::KeyStoreHandlerSigner,
 };
+use crate::{plugin::PluginManager, subcommands::util::map_tx_builder_error_2_str};
 
 // Max derived change address to search
 const DERIVE_CHANGE_ADDRESS_MAX_LEN: u32 = 10000;
@@ -411,7 +411,9 @@ impl<'a> WalletSubCommand<'a> {
                 &balancer,
                 &unlockers,
             )
-            .map_err(|err| err.to_string())?;
+            .map_err(|err| {
+                map_tx_builder_error_2_str(balancer.force_small_change_as_fee.is_none(), err)
+            })?;
         if is_type_id {
             let mut blake2b = new_blake2b();
             let first_cell_input = tx.inputs().into_iter().next().expect("inputs empty");

--- a/src/utils/arg.rs
+++ b/src/utils/arg.rs
@@ -137,13 +137,14 @@ pub fn fee_rate<'a>() -> Arg<'a> {
         .about("The transaction fee rate (unit: shannons/KB)")
 }
 
-pub fn force_small_change_as_fee<'a>() -> Arg<'a> {
-    Arg::with_name("force-small-change-as-fee")
-        .long("force-small-change-as-fee")
+/// create an Arg object to receive value of force_small_change_as_fee for CapacityBalancer
+pub fn max_tx_fee<'a>() -> Arg<'a> {
+    Arg::with_name("max-tx-fee")
+        .long("max-tx-fee")
         .takes_value(true)
         .value_name("capacity")
         .validator(|input|CapacityParser.validate(input))
-        .about("When there is no more inputs for create a change cell to balance the transaction capacity, force the addition capacity as fee, the value is actual maximum transaction fee.")
+        .about("When there is no more inputs for create a change cell to balance the transaction capacity, force the addition capacity as fee, the value is actual maximum transaction fee(unit CKB, example:0.001)")
 }
 
 pub fn live_cells_limit<'a>() -> Arg<'a> {

--- a/src/utils/arg.rs
+++ b/src/utils/arg.rs
@@ -145,6 +145,15 @@ pub fn fee_rate<'a>() -> Arg<'a> {
         .about("The transaction fee rate (unit: shannons/KB)")
 }
 
+pub fn force_small_change_as_fee<'a>() -> Arg<'a> {
+    Arg::with_name("force-small-change-as-fee")
+        .long("force-small-change-as-fee")
+        .takes_value(true)
+        .value_name("capacity")
+        .validator(|input|CapacityParser.validate(input))
+        .about("When there is no more inputs for create a change cell to balance the transaction capacity, force the addition capacity as fee, the value is actual maximum transaction fee.")
+}
+
 pub fn live_cells_limit<'a>() -> Arg<'a> {
     Arg::with_name("limit")
         .long("limit")

--- a/src/utils/arg.rs
+++ b/src/utils/arg.rs
@@ -2,7 +2,7 @@ use crate::utils::arg_parser::{
     AddressParser, ArgParser, CapacityParser, FilePathParser, FixedHashParser, FromStrParser,
     HexParser, OutPointParser, PrivkeyPathParser, PubkeyHexParser,
 };
-use ckb_types::{H160, H256};
+use ckb_types::H160;
 use clap::Arg;
 
 pub fn privkey_path<'a>() -> Arg<'a> {
@@ -29,14 +29,6 @@ pub fn address<'a>() -> Arg<'a> {
         .about(
             "Target address (see: https://github.com/nervosnetwork/rfcs/blob/master/rfcs/0021-ckb-address-format/0021-ckb-address-format.md)",
         )
-}
-
-pub fn lock_hash<'a>() -> Arg<'a> {
-    Arg::with_name("lock-hash")
-        .long("lock-hash")
-        .takes_value(true)
-        .validator(|input| FixedHashParser::<H256>::default().validate(input))
-        .about("Lock hash")
 }
 
 pub fn derive_receiving_address_length<'a>() -> Arg<'a> {


### PR DESCRIPTION
# Features
- Add parameter force-small-change-as-fee to `wallet transfer`.
- Remove `conflicts_with` parameter `lock-hash`, so `wallet get-capacity` won't break on debug mode.