### PR TITLE
Fix directory and files permission on `unix` platform

### DIFF
--- a/src/utils/other.rs
+++ b/src/utils/other.rs
@@ -1,6 +1,8 @@
 use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::io::Read;
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 use std::path::PathBuf;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -52,11 +54,18 @@ pub fn read_password(repeat: bool, prompt: Option<&str>) -> Result<String, Strin
 pub fn get_key_store(ckb_cli_dir: PathBuf) -> Result<KeyStore, String> {
     let mut keystore_dir = ckb_cli_dir;
     keystore_dir.push("keystore");
-    fs::create_dir_all(&keystore_dir)
-        .map_err(|err| err.to_string())
-        .and_then(|_| {
-            KeyStore::from_dir(keystore_dir, ScryptType::default()).map_err(|err| err.to_string())
-        })
+    fs::create_dir_all(&keystore_dir).map_err(|err| err.to_string())?;
+
+    #[cfg(unix)]
+    fs::set_permissions(&keystore_dir, fs::Permissions::from_mode(0o700)).map_err(|err| {
+        format!(
+            "failed to set permission for  keystore: {:?}, err: {:?}",
+            keystore_dir,
+            err.to_string()
+        )
+    })?;
+
+    KeyStore::from_dir(keystore_dir, ScryptType::default()).map_err(|err| err.to_string())
 }
 
 pub fn get_address(network: Option<NetworkType>, m: &ArgMatches) -> Result<AddressPayload, String> {

--- a/test/src/main.rs
+++ b/test/src/main.rs
@@ -7,6 +7,7 @@ pub mod util;
 use crate::app::App;
 use crate::setup::Setup;
 use crate::spec::{
+    AccountKeystoreExportPerm, AccountKeystorePerm, AccountKeystoreUpdatePassword,
     DaoPrepareMultiple, DaoPrepareOne, DaoWithdrawMultiple, Plugin, RpcGetTipBlockNumber, Spec,
     SudtIssueToAcp, SudtIssueToCheque, SudtTransferToChequeForClaim,
     SudtTransferToChequeForWithdraw, SudtTransferToMultiAcp, Util, WalletTimelockedAddress,
@@ -70,6 +71,9 @@ fn run_spec(spec: Box<dyn Spec>, app: &App) {
 
 fn all_specs() -> Vec<Box<dyn Spec>> {
     vec![
+        Box::new(AccountKeystorePerm),
+        Box::new(AccountKeystoreExportPerm),
+        Box::new(AccountKeystoreUpdatePassword),
         Box::new(SudtIssueToCheque),
         Box::new(SudtIssueToAcp),
         Box::new(SudtTransferToMultiAcp),

--- a/test/src/spec/account_keystore_perm.rs
+++ b/test/src/spec/account_keystore_perm.rs
@@ -1,0 +1,157 @@
+use crate::setup::Setup;
+use crate::spec::Spec;
+use log::info;
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::{env, fs};
+use tempfile::tempdir;
+
+pub struct AccountKeystorePerm;
+
+const CLI_PASSWORD: &str = "abc123456";
+
+impl Spec for AccountKeystorePerm {
+    fn run(&self, setup: &mut Setup) {
+        let output = setup.cli_command(&["account", "new"], &[CLI_PASSWORD, CLI_PASSWORD]);
+        info!("output = {}", output);
+        assert!(output.contains("lock_arg: "));
+        assert!(output.contains("lock_hash: "));
+
+        // get lock_args: from output
+        let lock_arg = output.split("lock_arg: ").collect::<Vec<&str>>()[1]
+            .split('\n')
+            .collect::<Vec<&str>>()[0];
+        info!("lock_arg = {}", lock_arg);
+
+        let ckb_cli_home = env::var("CKB_CLI_HOME").expect("CKB_CLI_HOME not set");
+        info!("ckb_cli_home = {}", ckb_cli_home);
+
+        // print a number to octal
+        let keystore_path = PathBuf::from(ckb_cli_home).join("keystore");
+        info!(
+            "keystore: 0o{:o}",
+            fs::metadata(&keystore_path).unwrap().permissions().mode()
+        );
+        assert_eq!(
+            fs::metadata(&keystore_path).unwrap().permissions().mode(),
+            0o40700
+        );
+
+        // iterator files under keystore_path
+        fs::read_dir(keystore_path).unwrap().for_each(|file| {
+            let file_path = file.unwrap().path();
+            info!(
+                "file: {}: 0o{:o}",
+                file_path.display(),
+                fs::metadata(&file_path).unwrap().permissions().mode(),
+            );
+            assert_eq!(
+                fs::metadata(&file_path).unwrap().permissions().mode(),
+                0o100600
+            );
+        })
+    }
+
+    fn spec_name(&self) -> &'static str {
+        "AccountKeystorePerm"
+    }
+}
+
+pub struct AccountKeystoreExportPerm;
+
+impl Spec for AccountKeystoreExportPerm {
+    fn run(&self, setup: &mut Setup) {
+        let output = setup.cli_command(&["account", "new"], &[CLI_PASSWORD, CLI_PASSWORD]);
+        info!("output = {}", output);
+        assert!(output.contains("lock_arg: "));
+        assert!(output.contains("lock_hash: "));
+        // get lock_args: from output
+        let lock_arg = output.split("lock_arg: ").collect::<Vec<&str>>()[1]
+            .split('\n')
+            .collect::<Vec<&str>>()[0];
+        info!("lock_arg = {}", lock_arg);
+
+        let ckb_cli_home = env::var("CKB_CLI_HOME").expect("CKB_CLI_HOME not set");
+        info!("ckb_cli_home = {}", ckb_cli_home);
+
+        let export_dir = tempdir().expect("create temp dir failed");
+        let export_file = export_dir.path().join("export.private");
+
+        assert!(export_file.is_absolute());
+
+        let output = setup.cli_command(
+            &[
+                "account",
+                "export",
+                "--lock-arg",
+                lock_arg,
+                "--extended-privkey-path",
+                export_file.to_str().unwrap(),
+            ],
+            &[CLI_PASSWORD],
+        );
+        assert!(output.contains("Success exported account as extended privkey to"));
+
+        info!(
+            "export.privkey : 0o{:o}",
+            fs::metadata(&export_file).unwrap().permissions().mode()
+        );
+        assert_eq!(
+            fs::metadata(&export_file).unwrap().permissions().mode(),
+            0o100400
+        );
+    }
+
+    fn spec_name(&self) -> &'static str {
+        "AccountKeystoreExportPerm"
+    }
+}
+
+pub struct AccountKeystoreUpdatePassword;
+
+impl Spec for AccountKeystoreUpdatePassword {
+    fn run(&self, setup: &mut Setup) {
+        let output = setup.cli_command(&["account", "new"], &[CLI_PASSWORD, CLI_PASSWORD]);
+        info!("output = {}", output);
+        assert!(output.contains("lock_arg: "));
+        assert!(output.contains("lock_hash: "));
+
+        // get lock_args: from output
+        let lock_arg = output.split("lock_arg: ").collect::<Vec<&str>>()[1]
+            .split('\n')
+            .collect::<Vec<&str>>()[0];
+        info!("lock_arg = {}", lock_arg);
+
+        let ckb_cli_home = env::var("CKB_CLI_HOME").expect("CKB_CLI_HOME not set");
+        info!("ckb_cli_home = {}", ckb_cli_home);
+
+        let keystore_path = PathBuf::from(ckb_cli_home).join("keystore");
+
+        const NEW_CLI_PASSWORD: &str = "new_1234567a";
+        let output = setup.cli_command(
+            &["account", "update", "--lock-arg", lock_arg],
+            &[CLI_PASSWORD, NEW_CLI_PASSWORD, NEW_CLI_PASSWORD],
+        );
+        info!("output = {}", output);
+
+        assert!(output.contains("status: success"));
+
+        // iterator files under keystore_path
+        fs::read_dir(keystore_path).unwrap().for_each(|file| {
+            let file_path = file.unwrap().path();
+            info!(
+                "file: {}: 0o{:o}",
+                file_path.display(),
+                fs::metadata(&file_path).unwrap().permissions().mode(),
+            );
+            assert_eq!(
+                fs::metadata(&file_path).unwrap().permissions().mode(),
+                0o100600
+            );
+        })
+    }
+
+    fn spec_name(&self) -> &'static str {
+        "AccountKeystoreUpdatePassword"
+    }
+}

--- a/test/src/spec/mod.rs
+++ b/test/src/spec/mod.rs
@@ -1,3 +1,4 @@
+mod account_keystore_perm;
 mod dao;
 mod plugin;
 mod rpc;
@@ -5,6 +6,7 @@ mod udt;
 mod util;
 mod wallet;
 
+pub use account_keystore_perm::*;
 pub use dao::*;
 pub use plugin::*;
 pub use rpc::*;


### PR DESCRIPTION
This PR want to:
- [x] set `keystore` directory's permission to `drwx------`
- [x] set files under `keystore`'s permission to `-rw-------`
- [x] set exported file by `ckb-cli account export`'s permission to `-r--------`

![image](https://github.com/nervosnetwork/ckb-cli/assets/46400566/65cdb7e7-c2fb-4b7b-b680-bf05fe92049d)

Request for review: @zhangsoledad @doitian 