### PR TITLE
[Fix] Type of `secp256k1_data.out_point.index` for `ckb util genesis-scripts` should be hex encoded

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1510,9 +1510,9 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
+checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "hmac"
@@ -1694,7 +1694,7 @@ version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c66c74d2ae7e79a5a8f7ac924adbe38ee42a859c6539ad869eb51f0b52dc220"
 dependencies = [
- "hermit-abi 0.3.1",
+ "hermit-abi 0.3.2",
  "libc",
  "windows-sys 0.48.0",
 ]

--- a/src/subcommands/util.rs
+++ b/src/subcommands/util.rs
@@ -802,7 +802,7 @@ message = "0x"
                     "secp256k1_data": {
                         "out_point": {
                             "tx_hash": genesis_cellbase_tx_hash,
-                            "index": 3,
+                            "index": json_types::Uint32::from(3),
                         }
                     },
                     "type_id": {


### PR DESCRIPTION
Fix #564 

After fix:
![image](https://github.com/nervosnetwork/ckb-cli/assets/46400566/eee20e22-71c1-4652-a083-7251ba4c9f0f)
