### PR TITLE
feat: addition of subcommands for CKB Indexer RPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -879,7 +879,7 @@ dependencies = [
  "atty",
  "bitflags",
  "clap_derive",
- "indexmap",
+ "indexmap 1.9.3",
  "lazy_static",
  "os_str_bytes",
  "strsim",
@@ -1067,7 +1067,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "907076dfda823b0b36d2a1bb5f90c96660a5bbcd7729e10727f07858f22c4edc"
 dependencies = [
  "cfg-if 1.0.0",
- "hashbrown",
+ "hashbrown 0.12.3",
  "lock_api",
  "once_cell",
  "parking_lot_core 0.9.8",
@@ -1223,6 +1223,12 @@ dependencies = [
  "regex",
  "termcolor",
 ]
+
+[[package]]
+name = "equivalent"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "errno"
@@ -1506,9 +1512,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.3.19"
+version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d357c7ae988e7d2182f7d7871d0b963962420b0678b0997ce7de72001aeab782"
+checksum = "bb2c4422095b67ee78da96fbb51a4cc413b3b25883c7717ff7ca1ab31022c9c9"
 dependencies = [
  "bytes 1.4.0",
  "fnv",
@@ -1516,7 +1522,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap",
+ "indexmap 2.2.2",
  "slab",
  "tokio",
  "tokio-util 0.7.8",
@@ -1531,6 +1537,12 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 dependencies = [
  "ahash",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f1a1d9242c78d09ce40a5e87e7554ee637af1351968159f4952f028f75604"
 
 [[package]]
 name = "heapsize"
@@ -1733,7 +1745,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg 1.1.0",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824b2ae422412366ba479e8111fd301f7b5faece8149317bb81925979a53f520"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.14.3",
 ]
 
 [[package]]
@@ -1974,7 +1996,7 @@ version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
 dependencies = [
- "hashbrown",
+ "hashbrown 0.12.3",
 ]
 
 [[package]]
@@ -3025,7 +3047,7 @@ version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "578a7433b776b56a35785ed5ce9a7e777ac0598aac5a6dd1b4b18a307c7fc71b"
 dependencies = [
- "indexmap",
+ "indexmap 1.9.3",
  "ryu",
  "serde",
  "yaml-rust",

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ hash: 0x0384ebc55b7cb56e51044743e05fb83a4edb7173524339c35df4c71fcdb0854d
 
 ### Example: Get live cell (json output format)
 ```
-ckb-cli rpc get_live_cell --tx-hash 0x4ec75b5a8de8d180853d5046760a99285c73283a5dc528f81d6ee056f5335172 --index 0 --output-format json
+ckb-cli rpc get_live_cell --tx-hash 0x4ec75b5a8de8d180853d5046760a99285c73283a5dc528f81d6ee056f5335172 --index 0
 ```
 
 **Response:**
@@ -90,3 +90,49 @@ ckb-cli rpc get_live_cell --tx-hash 0x4ec75b5a8de8d180853d5046760a99285c73283a5d
   "status": "live"
 }
 ```
+
+### Example: Indexer get cells (yaml output format)
+
+Prepare file searchkey.json as input parameters:
+
+```json
+{
+    "script": {
+        "code_hash": "0xbbad126377d45f90a8ee120da988a2d7332c78ba8fd679aab478a19d6c133494",
+        "hash_type": "data1",
+        "args": "0x"
+    },
+    "script_type": "type",
+    "script_search_mode": "prefix",
+    "filter": {
+        "output_data": "0xa58618a553",
+        "output_data_filter_mode": "partial"
+    },
+    "with_data": false
+}
+```
+
+```
+ckb-cli rpc get_transactions --json-path ./searchkey.json --order asc --limit 3
+```
+Response:
+
+```yaml
+last_cursor: 0xa0bbad126377d45f90a8ee120da988a2d7332c78ba8fd679aab478a19d6c13349402013368282f4cde04254a3a6a2027b33f7c974046a4d5cbd96bc47d7f058c18090000000000b29e04000000050000000000
+objects:
+  - block_number: 10375179
+    io_index: 1
+    io_type: output
+    tx_hash: 0x551ec96717c336b74bbb2e56a1cb9c73e2a9d4b56321079b454cfc1c0e6036ac
+    tx_index: 7
+  - block_number: 11705844
+    io_index: 0
+    io_type: output
+    tx_hash: 0xd690aa336c0d05808e08a97ba2f3031b7691341df9002b305c2d27cb116e2705
+    tx_index: 5
+  - block_number: 11705860
+    io_index: 0
+    io_type: input
+    tx_hash: 0xa3282c23227992933eee0a07e5cbf52ca62006b98f2d113ebf579c5e59cf5a62
+    tx_index: 5
+  ```

--- a/src/subcommands/rpc.rs
+++ b/src/subcommands/rpc.rs
@@ -349,7 +349,9 @@ impl<'a> RpcSubCommand<'a> {
                             .validator(|input| HexParser.validate(input))
                             .about("Block assembler message (hex format)")
                     )
-                    .about("[TEST ONLY] Generate an empty block")
+                    .about("[TEST ONLY] Generate an empty block"),
+                // [`Indexer`]
+                App::new("get_indexer_tip").about("Returns the indexed tip"),
             ])
     }
 }
@@ -1067,6 +1069,20 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                     .rpc_client
                     .generate_block(script_opt, message_opt.map(JsonBytes::from_bytes))?;
                 Ok(Output::new_output(resp))
+            }
+            // [Indexer]
+            ("get_indexer_tip", Some(m)) => {
+                let is_raw_data = is_raw_data || m.is_present("raw-data");
+                if is_raw_data {
+                    let resp = self
+                        .raw_rpc_client
+                        .get_indexer_tip()
+                        .map_err(|err| err.to_string())?;
+                    Ok(Output::new_output(resp))
+                } else {
+                    let resp = self.rpc_client.get_indexer_tip()?;
+                    Ok(Output::new_output(resp))
+                }
             }
             _ => Err(Self::subcommand().generate_usage()),
         }

--- a/src/subcommands/rpc.rs
+++ b/src/subcommands/rpc.rs
@@ -384,6 +384,15 @@ impl<'a> RpcSubCommand<'a> {
                             .about("Pagination parameter")
                     )
                     .about("Returns the live cells collection by the lock or type script"),
+                    App::new("get_cells_capacity")
+                    .arg(
+                        Arg::with_name("json-path")
+                        .long("json-path")
+                        .takes_value(true)
+                        .validator(|input| FilePathParser::new(true).validate(input))
+                        .required(true)
+                        .about("Indexer search key"))
+                    .about("Returns the live cells capacity by the lock or type script"),
             ])
     }
 }
@@ -1140,6 +1149,25 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                     let resp =
                         self.rpc_client
                             .get_cells(search_key, order, limit.into(), after_opt)?;
+                    Ok(Output::new_output(resp))
+                }
+            }
+            ("get_cells_capacity", Some(m)) => {
+                let json_path: PathBuf = FilePathParser::new(true)
+                    .from_matches_opt(m, "json-path")?
+                    .expect("json-path is required");
+                let content = fs::read_to_string(json_path).map_err(|err| err.to_string())?;
+                let search_key = serde_json::from_str(&content).map_err(|err| err.to_string())?;
+
+                let is_raw_data = is_raw_data || m.is_present("raw-data");
+                if is_raw_data {
+                    let resp = self
+                        .raw_rpc_client
+                        .get_cells_capacity(search_key)
+                        .map_err(|err| err.to_string())?;
+                    Ok(Output::new_output(resp))
+                } else {
+                    let resp = self.rpc_client.get_cells_capacity(search_key)?;
                     Ok(Output::new_output(resp))
                 }
             }

--- a/src/subcommands/rpc.rs
+++ b/src/subcommands/rpc.rs
@@ -16,7 +16,7 @@ use crate::utils::arg_parser::{
     FromStrParser, HexParser,
 };
 use crate::utils::rpc::{
-    BannedAddr, BlockEconomicState, BlockView, EpochView, HeaderView, HttpRpcClient,
+    parse_order, BannedAddr, BlockEconomicState, BlockView, EpochView, HeaderView, HttpRpcClient,
     RawHttpRpcClient, RemoteNode, Timestamp, TransactionProof, TransactionWithStatus,
 };
 
@@ -352,6 +352,38 @@ impl<'a> RpcSubCommand<'a> {
                     .about("[TEST ONLY] Generate an empty block"),
                 // [`Indexer`]
                 App::new("get_indexer_tip").about("Returns the indexed tip"),
+                App::new("get_cells")
+                    .arg(
+                        Arg::with_name("json-path")
+                        .long("json-path")
+                        .takes_value(true)
+                        .validator(|input| FilePathParser::new(true).validate(input))
+                        .required(true)
+                        .about("Indexer search key"))
+                    .arg(
+                        Arg::with_name("order")
+                            .long("order")
+                            .takes_value(true)
+                            .possible_values(&["asc", "desc"])
+                            .required(true)
+                            .about("Indexer search order")
+                    )
+                    .arg(
+                        Arg::with_name("limit")
+                            .long("limit")
+                            .takes_value(true)
+                            .validator(|input| FromStrParser::<u64>::default().validate(input))
+                            .required(true)
+                            .about("Limit the number of results")
+                    )
+                    .arg(
+                        Arg::with_name("after")
+                            .long("after")
+                            .takes_value(true)
+                            .validator(|input| HexParser.validate(input))
+                            .about("Pagination parameter")
+                    )
+                    .about("Returns the live cells collection by the lock or type script"),
             ])
     }
 }
@@ -1081,6 +1113,33 @@ impl<'a> CliSubCommand for RpcSubCommand<'a> {
                     Ok(Output::new_output(resp))
                 } else {
                     let resp = self.rpc_client.get_indexer_tip()?;
+                    Ok(Output::new_output(resp))
+                }
+            }
+            ("get_cells", Some(m)) => {
+                let json_path: PathBuf = FilePathParser::new(true)
+                    .from_matches_opt(m, "json-path")?
+                    .expect("json-path is required");
+                let content = fs::read_to_string(json_path).map_err(|err| err.to_string())?;
+                let search_key = serde_json::from_str(&content).map_err(|err| err.to_string())?;
+                let order_str = m.value_of("order").expect("order is required");
+                let order = parse_order(order_str)?;
+                let limit: u32 = FromStrParser::<u32>::default().from_matches(m, "limit")?;
+                let after_opt: Option<JsonBytes> = HexParser
+                    .from_matches_opt::<Bytes>(m, "after")?
+                    .map(JsonBytes::from_bytes);
+
+                let is_raw_data = is_raw_data || m.is_present("raw-data");
+                if is_raw_data {
+                    let resp = self
+                        .raw_rpc_client
+                        .get_cells(search_key, order, limit.into(), after_opt)
+                        .map_err(|err| err.to_string())?;
+                    Ok(Output::new_output(resp))
+                } else {
+                    let resp =
+                        self.rpc_client
+                            .get_cells(search_key, order, limit.into(), after_opt)?;
                     Ok(Output::new_output(resp))
                 }
             }

--- a/src/utils/rpc/client.rs
+++ b/src/utils/rpc/client.rs
@@ -411,4 +411,12 @@ impl HttpRpcClient {
             .notify_transaction(tx.into())
             .map_err(|err| err.to_string())
     }
+
+    // Indexer
+    pub fn get_indexer_tip(&mut self) -> Result<Option<types::IndexerTip>, String> {
+        self.client
+            .get_indexer_tip()
+            .map(|opt| opt.map(Into::into))
+            .map_err(|err| err.to_string())
+    }
 }

--- a/src/utils/rpc/client.rs
+++ b/src/utils/rpc/client.rs
@@ -437,4 +437,14 @@ impl HttpRpcClient {
             })
             .map_err(|err| err.to_string())
     }
+
+    pub fn get_cells_capacity(
+        &mut self,
+        search_key: SearchKey,
+    ) -> Result<Option<types::CellsCapacity>, String> {
+        self.client
+            .get_cells_capacity(search_key)
+            .map(|opt| opt.map(Into::into))
+            .map_err(|err| err.to_string())
+    }
 }

--- a/src/utils/rpc/client.rs
+++ b/src/utils/rpc/client.rs
@@ -438,6 +438,22 @@ impl HttpRpcClient {
             .map_err(|err| err.to_string())
     }
 
+    pub fn get_transactions(
+        &mut self,
+        search_key: SearchKey,
+        order: Order,
+        limit: Uint32,
+        after: Option<JsonBytes>,
+    ) -> Result<Pagination<types::Tx>, String> {
+        self.client
+            .get_transactions(search_key, order, limit, after)
+            .map(|p| Pagination {
+                objects: p.objects.into_iter().map(Into::into).collect(),
+                last_cursor: p.last_cursor,
+            })
+            .map_err(|err| err.to_string())
+    }
+
     pub fn get_cells_capacity(
         &mut self,
         search_key: SearchKey,

--- a/src/utils/rpc/mod.rs
+++ b/src/utils/rpc/mod.rs
@@ -6,10 +6,11 @@ mod types;
 pub use client::{HttpRpcClient, RawHttpRpcClient};
 pub use primitive::{Capacity, EpochNumberWithFraction, Since, Timestamp};
 pub use types::{
-    Alert, AlertMessage, BannedAddr, Block, BlockEconomicState, BlockIssuance, BlockResponse,
-    BlockView, Byte32, CellDep, CellInput, CellOutput, ChainInfo, DepType, EpochView, Header,
-    HeaderView, JsonBytes, LocalNode, MerkleProof, MinerReward, NodeAddress, OutPoint,
-    PackedBlockResponse, ProposalShortId, RemoteNode, Script, ScriptHashType, Transaction,
-    TransactionAndWitnessProof, TransactionProof, TransactionView, TransactionWithStatus,
-    TransactionWithStatusResponse, TxPoolInfo, TxStatus, Uint128, UncleBlock, UncleBlockView,
+    parse_order, Alert, AlertMessage, BannedAddr, Block, BlockEconomicState, BlockIssuance,
+    BlockResponse, BlockView, Byte32, CellDep, CellInput, CellOutput, ChainInfo, DepType,
+    EpochView, Header, HeaderView, JsonBytes, LocalNode, MerkleProof, MinerReward, NodeAddress,
+    OutPoint, PackedBlockResponse, ProposalShortId, RemoteNode, Script, ScriptHashType,
+    Transaction, TransactionAndWitnessProof, TransactionProof, TransactionView,
+    TransactionWithStatus, TransactionWithStatusResponse, TxPoolInfo, TxStatus, Uint128,
+    UncleBlock, UncleBlockView,
 };

--- a/src/utils/rpc/types.rs
+++ b/src/utils/rpc/types.rs
@@ -1741,6 +1741,22 @@ impl From<ckb_indexer::Cell> for Cell {
     }
 }
 
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(untagged)]
+pub enum Tx {
+    Ungrouped(TxWithCell),
+    Grouped(TxWithCells),
+}
+
+impl From<ckb_indexer::Tx> for Tx {
+    fn from(tx: ckb_indexer::Tx) -> Tx {
+        match tx {
+            ckb_indexer::Tx::Ungrouped(tx_with_cell) => Tx::Ungrouped(tx_with_cell.into()),
+            ckb_indexer::Tx::Grouped(tx_with_cells) => Tx::Grouped(tx_with_cells.into()),
+        }
+    }
+}
+
 /// Response type of the RPC method `get_transactions`.
 #[derive(Serialize, Deserialize, Clone, Debug)]
 pub struct TxWithCell {

--- a/src/utils/rpc/types.rs
+++ b/src/utils/rpc/types.rs
@@ -11,7 +11,7 @@ use ckb_types::{core, packed, prelude::*, H256, U256};
 use super::primitive::{Capacity, EpochNumberWithFraction, Since, Timestamp};
 use crate::utils::rpc::json_rpc;
 use ckb_sdk::constants::{DAO_TYPE_HASH, MULTISIG_TYPE_HASH, SIGHASH_TYPE_HASH};
-use ckb_sdk::rpc::ckb_indexer::{self, CellType};
+use ckb_sdk::rpc::ckb_indexer::{self, CellType, Order};
 
 type Version = u32;
 type BlockNumber = u64;
@@ -1802,5 +1802,13 @@ impl From<ckb_indexer::CellsCapacity> for CellsCapacity {
             block_hash: json.block_hash,
             block_number: json.block_number.into(),
         }
+    }
+}
+
+pub fn parse_order(order_str: &str) -> Result<Order, String> {
+    match order_str.to_lowercase().as_str() {
+        "desc" => Ok(Order::Desc),
+        "asc" => Ok(Order::Asc),
+        _ => Err(format!("Invalid order: {}", order_str)),
     }
 }

--- a/src/utils/rpc/types.rs
+++ b/src/utils/rpc/types.rs
@@ -11,6 +11,7 @@ use ckb_types::{core, packed, prelude::*, H256, U256};
 use super::primitive::{Capacity, EpochNumberWithFraction, Since, Timestamp};
 use crate::utils::rpc::json_rpc;
 use ckb_sdk::constants::{DAO_TYPE_HASH, MULTISIG_TYPE_HASH, SIGHASH_TYPE_HASH};
+use ckb_sdk::rpc::ckb_indexer::{self, CellType};
 
 type Version = u32;
 type BlockNumber = u64;
@@ -1698,6 +1699,108 @@ impl From<rpc_types::FeeRateStatistics> for FeeRateStatistics {
         FeeRateStatistics {
             mean: json.mean.into(),
             median: json.median.into(),
+        }
+    }
+}
+
+/// Response type of the RPC method `get_indexer_tip`.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct IndexerTip {
+    pub block_hash: H256,
+    pub block_number: BlockNumber,
+}
+
+impl From<ckb_indexer::Tip> for IndexerTip {
+    fn from(tip: ckb_indexer::Tip) -> IndexerTip {
+        IndexerTip {
+            block_hash: tip.block_hash,
+            block_number: tip.block_number.into(),
+        }
+    }
+}
+
+/// Response type of the RPC method `get_cells`.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct Cell {
+    pub output: CellOutput,
+    pub output_data: Option<JsonBytes>,
+    pub out_point: OutPoint,
+    pub block_number: BlockNumber,
+    pub tx_index: Uint32,
+}
+
+impl From<ckb_indexer::Cell> for Cell {
+    fn from(cell: ckb_indexer::Cell) -> Cell {
+        Cell {
+            output: cell.output.into(),
+            output_data: cell.output_data.map(Into::into),
+            out_point: cell.out_point.into(),
+            block_number: cell.block_number.into(),
+            tx_index: cell.tx_index.into(),
+        }
+    }
+}
+
+/// Response type of the RPC method `get_transactions`.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct TxWithCell {
+    pub tx_hash: H256,
+    pub block_number: BlockNumber,
+    pub tx_index: Uint32,
+    pub io_index: Uint32,
+    pub io_type: CellType,
+}
+
+impl From<ckb_indexer::TxWithCell> for TxWithCell {
+    fn from(tx_with_cell: ckb_indexer::TxWithCell) -> TxWithCell {
+        TxWithCell {
+            tx_hash: tx_with_cell.tx_hash,
+            block_number: tx_with_cell.block_number.into(),
+            tx_index: tx_with_cell.tx_index.into(),
+            io_index: tx_with_cell.io_index.into(),
+            io_type: tx_with_cell.io_type,
+        }
+    }
+}
+
+/// Response type of the RPC method `get_transactions`.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct TxWithCells {
+    pub tx_hash: H256,
+    pub block_number: BlockNumber,
+    pub tx_index: Uint32,
+    pub cells: Vec<(CellType, Uint32)>,
+}
+
+impl From<ckb_indexer::TxWithCells> for TxWithCells {
+    fn from(tx_with_cells: ckb_indexer::TxWithCells) -> TxWithCells {
+        TxWithCells {
+            tx_hash: tx_with_cells.tx_hash,
+            block_number: tx_with_cells.block_number.into(),
+            tx_index: tx_with_cells.tx_index.into(),
+            cells: tx_with_cells
+                .cells
+                .into_iter()
+                .map(|(cell_type, io_index)| (cell_type, io_index.into()))
+                .collect(),
+        }
+    }
+}
+
+/// Response type of the RPC method `get_cells_capacity`.
+#[derive(Serialize, Deserialize, Clone, Debug)]
+pub struct CellsCapacity {
+    pub capacity: Capacity,
+    pub block_hash: H256,
+    pub block_number: BlockNumber,
+}
+
+impl From<ckb_indexer::CellsCapacity> for CellsCapacity {
+    fn from(json: ckb_indexer::CellsCapacity) -> CellsCapacity {
+        CellsCapacity {
+            capacity: json.capacity.into(),
+            block_hash: json.block_hash,
+            block_number: json.block_number.into(),
         }
     }
 }


### PR DESCRIPTION
issue: 
- https://github.com/nervosnetwork/ckb-cli/issues/578

This PR introduces new subcommands for the CKB Indexer RPC. The following commands have been added to enhance functionality and user interaction:

- `get_indexer_tip`: This command retrieves the latest tip from the indexer.
- `get_cells`: This command fetches live cells based on specified conditions.
- `get_transactions`: This command retrieves transactions based on given parameters.
- `get_cells_capacity`: This command calculates and returns the total capacity of the live cells.

