### PR TITLE
ci: declare permissions in package workflow

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -1,5 +1,9 @@
 name: Package
 
+permissions:
+  # for actions/create-release, actions/upload-release-asset
+  contents: write
+
 concurrency:
   group: package-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Declare `contents: write` for actions/create-release, actions/upload-release-asset
