### PR TITLE
feat: support force redeploy cells

### DIFF
--- a/src/subcommands/deploy/deployment.rs
+++ b/src/subcommands/deploy/deployment.rs
@@ -27,6 +27,8 @@ pub struct Cell {
     pub name: String,
     pub location: CellLocation,
     pub enable_type_id: bool,
+    #[serde(default)]
+    pub force_redeploy: bool,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]

--- a/src/subcommands/deploy/mod.rs
+++ b/src/subcommands/deploy/mod.rs
@@ -738,7 +738,8 @@ fn load_cells(
             let lock_script_unchanged = lock_script.as_slice() == old_lock_script.as_slice();
             let type_id_unchanged = old_recipe.type_id.is_some() == config.enable_type_id;
             // NOTE: we trust `old_recipe.data_hash` here
-            if data_unchanged && lock_script_unchanged && type_id_unchanged {
+            if data_unchanged && lock_script_unchanged && type_id_unchanged && !cell.force_redeploy
+            {
                 StateChange::Unchanged {
                     data,
                     data_hash,


### PR DESCRIPTION
Support using option `force_redeploy` to control which cell should be always force redeployed even the cell content isn't changed.

Usecase:

We deploy script cell and script config cell in the same deployment transaction, so we can use the transaction to locate the global config cell while the script is running.

But when updating the cells, `deploy` command will skip the config cell since it's content isn't changed, this behavior causes the script cell and config cell located into two transaction.