### PR TITLE
Fix deploy with multisig

### DIFF
--- a/src/subcommands/deploy/deployment.rs
+++ b/src/subcommands/deploy/deployment.rs
@@ -27,6 +27,8 @@ pub struct Cell {
     pub name: String,
     pub location: CellLocation,
     pub enable_type_id: bool,
+    #[serde(default)]
+    pub force_redeploy: bool,
 }
 
 #[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize)]

--- a/src/subcommands/deploy/mod.rs
+++ b/src/subcommands/deploy/mod.rs
@@ -738,7 +738,8 @@ fn load_cells(
             let lock_script_unchanged = lock_script.as_slice() == old_lock_script.as_slice();
             let type_id_unchanged = old_recipe.type_id.is_some() == config.enable_type_id;
             // NOTE: we trust `old_recipe.data_hash` here
-            if data_unchanged && lock_script_unchanged && type_id_unchanged {
+            if data_unchanged && lock_script_unchanged && type_id_unchanged && !cell.force_redeploy
+            {
                 StateChange::Unchanged {
                     data,
                     data_hash,

--- a/src/subcommands/tx.rs
+++ b/src/subcommands/tx.rs
@@ -811,17 +811,9 @@ impl TryFrom<ReprMultisigConfig> for MultisigConfig {
             .sighash_addresses
             .into_iter()
             .map(|address_string| {
-                if let AddressPayload::Short { index, hash } =
-                    Address::from_str(&address_string).map(|addr| addr.payload().clone())?
-                {
-                    if index == CodeHashIndex::Sighash {
-                        Ok(hash)
-                    } else {
-                        Err(format!("invalid address: {}", address_string))
-                    }
-                } else {
-                    Err(format!("invalid address: {}", address_string))
-                }
+                Address::from_str(&address_string)
+                    .map(|addr| H160::from_slice(addr.payload().args().as_ref()))?
+                    .map_err(|err| format!("invalid address: {address_string} error: {err:?}"))
             })
             .collect::<Result<Vec<_>, String>>()?;
         MultisigConfig::new_with(sighash_addresses, repr.require_first_n, repr.threshold)


### PR DESCRIPTION
Deploy with multisig will output `invalid address` error if address isn't `Short`.

This PR fixed the issue by copy the parsing code from https://github.com/nervosnetwork/ckb-cli/blob/develop/src/subcommands/tx.rs#L575