### PR TITLE
chore(deps): upgrade openssl crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2313,9 +2313,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.64"
+version = "0.10.66"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95a0481286a310808298130d22dd1fef0fa571e05a8f44ec801801e84b216b1f"
+checksum = "9529f4786b70a3e8c61e11179af17ab6188ad8d0ded78c5529441ed39d4bd9c1"
 dependencies = [
  "bitflags 2.4.2",
  "cfg-if 1.0.0",
@@ -2354,9 +2354,9 @@ dependencies = [
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.101"
+version = "0.9.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dda2b0f344e78efc2facf7d195d098df0dd72151b26ab98da807afc26c198dff"
+checksum = "7f9e8deee91df40a943c71b917e5874b951d32a802526c85721ce3b776c929d6"
 dependencies = [
  "cc",
  "libc",


### PR DESCRIPTION
```
error[vulnerability]: `MemBio::get_buf` has undefined behavior with empty buffers
    ┌─ /home/runner/work/ckb/ckb/Cargo.lock:313:1
    │
313 │ openssl 0.10.64 registry+https://github.com/rust-lang/crates.io-index
    │ --------------------------------------------------------------------- security vulnerability detected
    │
    = ID: RUSTSEC-2024-0357
    = Advisory: https://rustsec.org/advisories/RUSTSEC-2024-0357
    = Previously, `MemBio::get_buf` called `slice::from_raw_parts` with a null-pointer, which violates the functions invariants, leading to undefined behavior. In debug builds this would produce an assertion failure. This is now fixed.
    = Announcement: https://github.com/sfackler/rust-openssl/pull/2266
    = Solution: Upgrade to >=0.10.66 (try `cargo update -p openssl`)
```
