### PR TITLE
fix: empty git commit version of cli

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -72,7 +72,7 @@ jobs:
         name: ckb-cli_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
         path: ckb-cli_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
     env:
-      BUILDER_IMAGE: nervos/ckb-docker-builder:bionic-rust-1.71.1-openssl-3.1.3
+      BUILDER_IMAGE: nervos/ckb-docker-builder:bionic-rust-1.75.0
       REL_PKG: x86_64-unknown-linux-gnu.tar.gz
 
   package-for-linux-aarch64:
@@ -146,7 +146,7 @@ jobs:
         name: ckb-cli_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
         path: ckb-cli_${{env.GIT_TAG_NAME }}_${{env.REL_PKG }}.asc
     env:
-      BUILDER_IMAGE: nervos/ckb-docker-builder:centos-7-rust-1.71.1-openssl-3.1.3
+      BUILDER_IMAGE: nervos/ckb-docker-builder:centos-7-rust-1.75.0
       REL_PKG: x86_64-unknown-centos-gnu.tar.gz
 
   package-for-mac:


### PR DESCRIPTION
Use ckb-docker-builder rust-1.75.0 to package ckb-cli

## What problem does this PR solve?
Issue Number: close nervosnetwork/ckb#4550 #609 #612

Problem Summary: When no git information was found, the sub-command --version outputs a pair of empty brackets.