### PR TITLE
add some useful subcmds to build complex transaction

### DIFF
--- a/src/utils/tx_helper.rs
+++ b/src/utils/tx_helper.rs
@@ -119,7 +119,7 @@ impl TxHelper {
                 cell_deps.insert(genesis_info.sighash_dep());
             } else if code_hash == MULTISIG_TYPE_HASH {
                 cell_deps.insert(genesis_info.multisig_dep());
-            } else {
+            } else if !skip_check {
                 panic!("Unexpected input code_hash: {:#x}", code_hash);
             }
         }


### PR DESCRIPTION
some useful subcmds to build complex transaction:
1. build-typeid-args
    when we want to create a typeid cell, it's args of type script is hash of inputs[0] and output index of typeid cell.
2.  amount2bytes
    when we create a xUDT cell, we need convert token amount to bytes as little end uint128
3. calc-type-hash
    typeid is hash of typeid cell's type script.
4. export-offline-tx
    tx json file created by ckb-cli can't offline signed by Neuron. Neuron need another format json file. this subcmd export tx to it.
5. fix skip check for add-input
    ckb-cli tx add-intput will return err when input's lock script is unknown in default. Add flag skip-check will ignore this case, but there is a bug, ckb-cli will panic even add flag skip-check.