### PR TITLE
`--zero-lock` only activate when code_hash is zero & hash_type is data and args is 0x

### DIFF
--- a/src/subcommands/mod.rs
+++ b/src/subcommands/mod.rs
@@ -82,12 +82,16 @@ pub trait CliSubCommand {
     fn process(&mut self, matches: &ArgMatches, debug: bool) -> Result<Output, String>;
 }
 
-pub(crate) static ALLOW_ZERO_LOCK_HELP_MSG: &str = "The --zero-lock option allows users to deploy a script permanently locked with an unspendable lock script. Once activated, the script becomes immutable and irreversible, ensuring no modifications or revocations can be made post-deployment.
+pub(crate) static ALLOW_ZERO_LOCK_HELP_MSG: &str = "The --zero-lock option allows users to deploy a script permanently locked with an unspendable lock script. This lock script is defined with the following parameters:
+
+- code_hash: 0x0000000000000000000000000000000000000000000000000000000000000000
+- hash_type: data
+- args: 0x
+
+Once activated, the script becomes immutable and irreversible, ensuring no modifications or revocations can be made post-deployment.
 
 Key Considerations:
 
-Permanent Immutability: Script logic and data will be permanently fixed on-chain.
-
-No Recovery Mechanism: If vulnerabilities or defects exist in the script, there is no way to upgrade, patch, or revoke it.
-
-Use with Caution: Thoroughly audit and test the script before deployment. This option is recommended only for scenarios requiring absolute finality, where script behavior must remain tamper-proof indefinitely.";
+- Permanent Immutability: Script logic and data will be permanently fixed on-chain.
+- No Recovery Mechanism: If vulnerabilities or defects exist in the script, there is no way to upgrade, patch, or revoke it.
+- Use with Caution: Thoroughly audit and test the script before deployment. This option is recommended only for scenarios requiring absolute finality, where script behavior must remain tamper-proof indefinitely.";

--- a/src/utils/tx_helper.rs
+++ b/src/utils/tx_helper.rs
@@ -442,9 +442,20 @@ pub fn check_lock_script(
             hash_type_str,
             lock_args.len()
         )),
-        (CodeHashCategory::Zero, _, _) if allow_zero_lock => Ok(()),
+        (CodeHashCategory::Zero, ScriptHashType::Data, 0) => {
+            if allow_zero_lock {
+                Ok(())
+            } else {
+                Err(format!(
+                    "Error: The code_hash is zero: {:#x}, hash_type: {}, args.length: {}. To permit a zero lock, please use the --zero-lock flag.",
+                    code_hash,
+                    hash_type_str,
+                    lock_args.len(),
+                ))
+            }
+        }
         (CodeHashCategory::Zero, _, _) => Err(format!(
-            "Error: The code_hash is zero: {:#x}, hash_type: {}, args.length: {}. To permit a zero lock, please use the --zero-lock flag.",
+            "Error: invalid lock script: The code_hash is zero: {:#x}, hash_type: {}, args.length: {}.",
             code_hash,
             hash_type_str,
             lock_args.len(),


### PR DESCRIPTION
Only allow the --zero-lock to activate when the script match 3 condition:
- code_hash: 0x000...000 (all zero)
- hash_type: data
- args: 0x
