### PR TITLE
allow `data1` and `data2` for `--zero-lock`

### DIFF
--- a/src/subcommands/deploy/mod.rs
+++ b/src/subcommands/deploy/mod.rs
@@ -493,7 +493,7 @@ impl CliSubCommand for DeploySubCommand<'_> {
                         .map_err(|err| err.to_string())?
                         .map(|helper| {
                             let _ = helper.check_tx(&mut get_live_cell, allow_zero_lock)?;
-                            helper.build_tx(&mut get_live_cell, skip_check, allow_zero_lock)
+                            helper.build_tx(&mut get_live_cell, skip_check)
                         })
                         .transpose()?;
                     let dep_group_tx_opt = info
@@ -501,7 +501,7 @@ impl CliSubCommand for DeploySubCommand<'_> {
                         .map_err(|err| err.to_string())?
                         .map(|helper| {
                             let _ = helper.check_tx(&mut get_live_cell, allow_zero_lock)?;
-                            helper.build_tx(&mut get_live_cell, skip_check, allow_zero_lock)
+                            helper.build_tx(&mut get_live_cell, skip_check)
                         })
                         .transpose()?;
                     (cell_tx_opt, dep_group_tx_opt)
@@ -645,12 +645,7 @@ fn sign_info(
             .check_tx(&mut get_live_cell, allow_zero_lock)
             .map_err(Error::msg)?;
         let signatures: HashMap<_, _> = helper
-            .sign_inputs(
-                &mut signer_fn,
-                &mut get_live_cell,
-                skip_check,
-                allow_zero_lock,
-            )
+            .sign_inputs(&mut signer_fn, &mut get_live_cell, skip_check)
             .map_err(Error::msg)?
             .into_iter()
             .map(|(k, v)| (JsonBytes::from_bytes(k), JsonBytes::from_bytes(v)))
@@ -681,12 +676,7 @@ fn sign_info(
             .check_tx(&mut get_live_cell, allow_zero_lock)
             .map_err(Error::msg)?;
         let signatures: HashMap<_, _> = helper
-            .sign_inputs(
-                &mut signer_fn,
-                &mut get_live_cell,
-                skip_check,
-                allow_zero_lock,
-            )
+            .sign_inputs(&mut signer_fn, &mut get_live_cell, skip_check)
             .map_err(Error::msg)?
             .into_iter()
             .map(|(k, v)| (JsonBytes::from_bytes(k), JsonBytes::from_bytes(v)))

--- a/src/subcommands/mock_tx.rs
+++ b/src/subcommands/mock_tx.rs
@@ -264,8 +264,6 @@ impl CliSubCommand for MockTxSubCommand<'_> {
                 let tx_file_opt: Option<PathBuf> =
                     FilePathParser::new(true).from_matches_opt(m, "tx-file")?;
 
-                let allow_zero_lock: bool = m.is_present("zero-lock");
-
                 let src_tx: json_types::Transaction = if let Some(path) = tx_file_opt {
                     let mut content = String::new();
                     let mut file = fs::File::open(path).map_err(|err| err.to_string())?;
@@ -279,7 +277,7 @@ impl CliSubCommand for MockTxSubCommand<'_> {
                             load_output_and_data(self.rpc_client, out_point.into())
                                 .map(|(output, _data, _)| output.into())
                         };
-                        let tx = helper.build_tx(&mut get_live_cell, true, allow_zero_lock)?;
+                        let tx = helper.build_tx(&mut get_live_cell, true)?;
                         tx.data().into()
                     } else {
                         serde_json::from_str(content.as_str()).map_err(|err| err.to_string())?

--- a/src/subcommands/mod.rs
+++ b/src/subcommands/mod.rs
@@ -85,7 +85,7 @@ pub trait CliSubCommand {
 pub(crate) static ALLOW_ZERO_LOCK_HELP_MSG: &str = "The --zero-lock option allows users to deploy a script permanently locked with an unspendable lock script. This lock script is defined with the following parameters:
 
 - code_hash: 0x0000000000000000000000000000000000000000000000000000000000000000
-- hash_type: data
+- hash_type: data/data1/data2
 - args: 0x
 
 Once activated, the script becomes immutable and irreversible, ensuring no modifications or revocations can be made post-deployment.

--- a/src/subcommands/rpc.rs
+++ b/src/subcommands/rpc.rs
@@ -1128,7 +1128,7 @@ impl CliSubCommand for RpcSubCommand<'_> {
                     serde_json::from_reader(&file).map_err(|err| err.to_string())?;
                 let helper = TxHelper::try_from(repr)?;
 
-                let tx_view = helper.build_tx(&mut get_live_cell, true, true)?;
+                let tx_view = helper.build_tx(&mut get_live_cell, true)?;
                 let tx = tx_view.data();
 
                 let is_raw_data = is_raw_data || m.is_present("raw-data");

--- a/src/subcommands/tx.rs
+++ b/src/subcommands/tx.rs
@@ -141,8 +141,7 @@ impl<'a> TxSubCommand<'a> {
                     )
                     .arg(arg_since_absolute_epoch.clone())
                     .arg(arg_tx_file.clone())
-                    .arg(arg_skip_check.clone())
-                    .arg(arg_allow_zero_lock.clone()),
+                    .arg(arg_skip_check.clone()),
                 App::new("add-output")
                     .about("Add cell output")
                     .arg(
@@ -215,8 +214,7 @@ impl<'a> TxSubCommand<'a> {
                             .long("add-signatures")
                             .about("Sign and add signatures"),
                     )
-                    .arg(arg_skip_check.clone())
-                    .arg(arg_allow_zero_lock.clone()),
+                    .arg(arg_skip_check.clone()),
                 App::new("send")
                     .about("Send multisig transaction")
                     .arg(arg_tx_file.clone())
@@ -287,7 +285,6 @@ impl CliSubCommand for TxSubCommand<'_> {
                     FromStrParser::<u64>::default().from_matches_opt(m, "since-absolute-epoch")?;
 
                 let skip_check: bool = m.is_present("skip-check");
-                let allow_zero_lock: bool = m.is_present("zero-lock");
                 let genesis_info = get_genesis_info(&self.genesis_info, self.rpc_client)?;
                 let out_point = OutPoint::new_builder()
                     .tx_hash(tx_hash.pack())
@@ -303,7 +300,6 @@ impl CliSubCommand for TxSubCommand<'_> {
                         get_live_cell,
                         &genesis_info,
                         skip_check,
-                        allow_zero_lock,
                     )
                 })?;
 
@@ -474,7 +470,6 @@ impl CliSubCommand for TxSubCommand<'_> {
                     })
                     .transpose()?;
                 let skip_check: bool = m.is_present("skip-check");
-                let allow_zero_lock: bool = m.is_present("zero-lock");
 
                 let mut signer = if let Some(privkey) = privkey_opt {
                     get_privkey_signer(privkey)
@@ -503,12 +498,7 @@ impl CliSubCommand for TxSubCommand<'_> {
                 };
 
                 let signatures = modify_tx_file(&tx_file, network, |helper| {
-                    let signatures = helper.sign_inputs(
-                        &mut signer,
-                        get_live_cell,
-                        skip_check,
-                        allow_zero_lock,
-                    )?;
+                    let signatures = helper.sign_inputs(&mut signer, get_live_cell, skip_check)?;
                     if m.is_present("add-signatures") {
                         for (lock_arg, signature) in signatures.clone() {
                             helper.add_signature(lock_arg, signature)?;
@@ -562,7 +552,7 @@ impl CliSubCommand for TxSubCommand<'_> {
                         ));
                     }
                 }
-                let tx = helper.build_tx(&mut get_live_cell, skip_check, allow_zero_lock)?;
+                let tx = helper.build_tx(&mut get_live_cell, skip_check)?;
                 let rpc_tx = json_types::Transaction::from(tx.data());
                 if debug {
                     eprintln!(

--- a/src/utils/tx_helper.rs
+++ b/src/utils/tx_helper.rs
@@ -442,7 +442,11 @@ pub fn check_lock_script(
             hash_type_str,
             lock_args.len()
         )),
-        (CodeHashCategory::Zero, ScriptHashType::Data, 0) => {
+        (
+            CodeHashCategory::Zero,
+            ScriptHashType::Data | ScriptHashType::Data1 | ScriptHashType::Data2,
+            0,
+        ) => {
             if allow_zero_lock {
                 Ok(())
             } else {

--- a/src/utils/tx_helper.rs
+++ b/src/utils/tx_helper.rs
@@ -89,10 +89,9 @@ impl TxHelper {
         mut get_live_cell: F,
         genesis_info: &GenesisInfo,
         skip_check: bool,
-        allow_zero_lock: bool,
     ) -> Result<(), String> {
         let lock = get_live_cell(out_point.clone(), false)?.lock();
-        check_lock_script(&lock, skip_check, allow_zero_lock)?;
+        check_lock_script(&lock, skip_check, /*allow_zero_lock:*/ false)?;
 
         let since = if let Some(number) = since_absolute_epoch_opt {
             Since::new_absolute_epoch(number).value()
@@ -114,10 +113,7 @@ impl TxHelper {
 
         self.transaction = self.transaction.as_advanced_builder().input(input).build();
         let mut cell_deps: HashSet<CellDep> = self.transaction.cell_deps().into_iter().collect();
-        for ((code_hash, _), _) in self
-            .input_group(get_live_cell, skip_check, allow_zero_lock)?
-            .into_iter()
-        {
+        for ((code_hash, _), _) in self.input_group(get_live_cell, skip_check)?.into_iter() {
             let code_hash: H256 = code_hash.unpack();
             if code_hash == SIGHASH_TYPE_HASH {
                 cell_deps.insert(genesis_info.sighash_dep());
@@ -176,12 +172,11 @@ impl TxHelper {
         &self,
         mut get_live_cell: F,
         skip_check: bool,
-        allow_zero_lock: bool,
     ) -> Result<HashMap<(Byte32, Bytes), Vec<usize>>, String> {
         let mut input_group: HashMap<(Byte32, Bytes), Vec<usize>> = HashMap::default();
         for (idx, input) in self.transaction.inputs().into_iter().enumerate() {
             let lock = get_live_cell(input.previous_output(), false)?.lock();
-            check_lock_script(&lock, skip_check, allow_zero_lock)
+            check_lock_script(&lock, skip_check, /*allow_zero_lock*/ false)
                 .map_err(|err| format!("Input(no.{}) {}", idx + 1, err))?;
 
             let lock_arg = lock.args().raw_data();
@@ -217,7 +212,6 @@ impl TxHelper {
         signer: &mut SignFn,
         get_live_cell: C,
         skip_check: bool,
-        allow_zero_lock: bool,
     ) -> Result<HashMap<Bytes, Bytes>, String>
     where
         C: FnMut(OutPoint, bool) -> Result<CellOutput, String>,
@@ -240,9 +234,8 @@ impl TxHelper {
         let witnesses = self.init_witnesses();
         let input_size = self.transaction.inputs().len();
         let mut signatures: HashMap<Bytes, Bytes> = Default::default();
-        for ((code_hash, lock_arg), idxs) in self
-            .input_group(get_live_cell, skip_check, allow_zero_lock)?
-            .into_iter()
+        for ((code_hash, lock_arg), idxs) in
+            self.input_group(get_live_cell, skip_check)?.into_iter()
         {
             if code_hash != SIGHASH_TYPE_HASH.pack() && code_hash != MULTISIG_TYPE_HASH.pack() {
                 continue;
@@ -280,12 +273,10 @@ impl TxHelper {
         &self,
         get_live_cell: F,
         skip_check: bool,
-        allow_zero_lock: bool,
     ) -> Result<TransactionView, String> {
         let mut witnesses = self.init_witnesses();
-        for ((code_hash, lock_arg), idxs) in self
-            .input_group(get_live_cell, skip_check, allow_zero_lock)?
-            .into_iter()
+        for ((code_hash, lock_arg), idxs) in
+            self.input_group(get_live_cell, skip_check)?.into_iter()
         {
             if skip_check && !self.signatures.contains_key(&lock_arg) {
                 continue;


### PR DESCRIPTION
This PR:
- Allow `data`, `data1` and `data2` for `--zero-lock` flag.
- remove useless `--zero-lock` flag on `tx add-input`.


Test: 
1. launch a ckb dev chain node. In ckb.toml, add `"Indexer"` to rpc_modules
2. create a deployment.toml
```toml
[[cells]]
name = "my_zero"
enable_type_id = false
location = { file = "zero/build/release/first-contract" }

[lock]
code_hash = "0x0000000000000000000000000000000000000000000000000000000000000000"
args = "0x"
hash_type = "data1"
```
3. run the test.sh to deploy the zero-lock contract:
```bash
#!/usr/bin/env bash
set -ex

ACCOUNT=ckt1qzda0cr08m85hc8jlnfp3zer7xulejywt49kt2rr0vthywaa50xwsqwgx292hnvmn68xf779vmzrshpmm6epn4c0cgwga


rm info.json || true
rm -rf migrations; mkdir migrations

PASSWORD=${PASSWORD}

echo $PASSWORD | ./ckb-cli deploy gen-txs \
    --deployment-config ./deployment.toml \
    --migration-dir ./migrations \
    --from-address ${ACCOUNT} \
    --sign-now \
    --info-file info.json || echo failed

echo $PASSWORD | ./ckb-cli deploy gen-txs \
    --deployment-config ./deployment.toml \
    --migration-dir ./migrations \
    --from-address ${ACCOUNT} \
    --sign-now \
    --info-file info.json --zero-lock

echo $PASSWORD | ./ckb-cli deploy sign-txs \
    --from-account ${ACCOUNT} \
    --add-signatures \
    --info-file info.json || echo failed

echo $PASSWORD | ./ckb-cli deploy sign-txs \
    --from-account ${ACCOUNT} \
    --add-signatures \
    --info-file info.json --zero-lock

echo $PASSWORD | ./ckb-cli deploy apply-txs --migration-dir ./migrations --info-file info.json || echo failed

echo $PASSWORD | ./ckb-cli deploy apply-txs --migration-dir ./migrations --info-file info.json --zero-lock

```
4. Execute `test.sh`: `PASSWORD=my_cli_password ./test.sh` 