### PR TITLE
fix: set `enable_type_id` to default false for serde for Cell and DepGroup

### DIFF
--- a/src/subcommands/deploy/deployment.rs
+++ b/src/subcommands/deploy/deployment.rs
@@ -26,6 +26,7 @@ pub enum CellLocation {
 pub struct Cell {
     pub name: String,
     pub location: CellLocation,
+    #[serde(default)]
     pub enable_type_id: bool,
     #[serde(default)]
     pub force_redeploy: bool,
@@ -35,6 +36,7 @@ pub struct Cell {
 pub struct DepGroup {
     pub name: String,
     pub cells: Vec<String>,
+    #[serde(default)]
     pub enable_type_id: bool,
 }
 


### PR DESCRIPTION
  Add `#[serde(default)]` attribute to enable_type_id fields in both Cell
  and DepGroup structs to ensure backwards compatibility when these fields
  are missing in deployment configuration files.

